### PR TITLE
Add wound & infection controls

### DIFF
--- a/src/components/steps/Step1_Clinical.jsx
+++ b/src/components/steps/Step1_Clinical.jsx
@@ -1,7 +1,7 @@
 import { Fragment } from 'react';
 import IconButton from '../UI/IconButton';
 
-const options = [
+const stageOptions = [
   { key: 'I',    label: 'Asymptomatic', icon: 'visibility' },
   { key: 'IIa',  label: 'Intermittent Claudication IIA', icon: 'walking' },
   { key: 'IIb',  label: 'Intermittent Claudication IIB', icon: 'running' },
@@ -9,15 +9,49 @@ const options = [
   { key: 'IV',   label: 'Ulcer/Gangrene', icon: 'warning' },
 ];
 
+const woundOptions = [
+  { key: '0', label: 'No wound',       icon: 'yes' },
+  { key: '1', label: 'Small ulcer',    icon: 'universal-access-alt' },
+  { key: '2', label: 'Deep ulcer',     icon: 'flag' },
+  { key: '3', label: 'Extensive',      icon: 'shield' },
+];
+
+const ischemiaOptions = [
+  { key: '0', label: 'None',         icon: 'yes' },
+  { key: '1', label: 'Mild',         icon: 'minus' },
+  { key: '2', label: 'Moderate',     icon: 'warning' },
+  { key: '3', label: 'Severe',       icon: 'dismiss' },
+];
+
+const infectionOptions = [
+  { key: '0', label: 'None',         icon: 'yes' },
+  { key: '1', label: 'Mild',         icon: 'minus' },
+  { key: '2', label: 'Moderate',     icon: 'warning' },
+  { key: '3', label: 'Severe',       icon: 'dismiss' },
+];
+
 export default function Step1({ data, setData }) {
   const selectStage = ( key ) => {
     setData({ ...data, stage: key });
   };
 
+  const selectWound = (key) => {
+    setData({ ...data, wound: key });
+  };
+
+  const selectIschemia = (key) => {
+    setData({ ...data, ischemia: key });
+  };
+
+  const selectInfection = (key) => {
+    setData({ ...data, infection: key });
+  };
+
   return (
     <Fragment>
+      <h3>Stage</h3>
       <div className="step1-grid">
-        { options.map((o) =>
+        { stageOptions.map((o) =>
           <IconButton
             key={o.key}
             icon={o.icon}
@@ -27,7 +61,42 @@ export default function Step1({ data, setData }) {
           />
         )}
       </div>
-      {/* Add similar icon-driven inputs for wound, ischemia, infection */}
+      <h3>Wound Grade</h3>
+      <div className="step1-grid">
+        { woundOptions.map((o) => (
+          <IconButton
+            key={o.key}
+            icon={o.icon}
+            label={o.label}
+            isSelected={ data.wound === o.key }
+            onClick={() => selectWound(o.key)}
+          />
+        )) }
+      </div>
+      <h3>Ischemia</h3>
+      <div className="step1-grid">
+        { ischemiaOptions.map((o) => (
+          <IconButton
+            key={o.key}
+            icon={o.icon}
+            label={o.label}
+            isSelected={ data.ischemia === o.key }
+            onClick={() => selectIschemia(o.key)}
+          />
+        )) }
+      </div>
+      <h3>Infection</h3>
+      <div className="step1-grid">
+        { infectionOptions.map((o) => (
+          <IconButton
+            key={o.key}
+            icon={o.icon}
+            label={o.label}
+            isSelected={ data.infection === o.key }
+            onClick={() => selectInfection(o.key)}
+          />
+        )) }
+      </div>
     </Fragment>
   );
 }

--- a/src/components/steps/Step3_Summary.jsx
+++ b/src/components/steps/Step3_Summary.jsx
@@ -17,7 +17,7 @@ export default function Step3({ data }) {
         <ul>
           <li><strong>Stage:</strong> {stage || '—'}</li>
           <li><strong>Wound Grade:</strong> {wound || '—'}</li>
-          <li><strong>Ischemia Level:</strong> {ischemia || '—'}</li>
+          <li><strong>Ischemia:</strong> {ischemia || '—'}</li>
           <li><strong>Infection:</strong> {infection || '—'}</li>
         </ul>
       </section>


### PR DESCRIPTION
## Summary
- add options for wound grade, ischemia, and infection in Step1
- show new clinical fields in the Step3 summary

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684087e8426483298ede435e582135ee