### PR TITLE
Fix Right External Iliac id typo

### DIFF
--- a/src/components/steps/Step2_Patency.jsx
+++ b/src/components/steps/Step2_Patency.jsx
@@ -10,7 +10,7 @@ const vesselSegments = [
   { id: 'Left_common_iliac_Afbeelding', name: 'Left Common Iliac' },
   { id: 'Right_common_iliac_Afbeelding', name: 'Right Common Iliac' },
   { id: 'Left_external_iliac_Afbeelding', name: 'Left External Iliac' },
-  { id: 'Right_extrnal_iliac_Afbeelding', name: 'Right External Iliac' },
+  { id: 'Right_external_iliac_Afbeelding', name: 'Right External Iliac' },
   { id: 'Left_internal_iliac_Afbeelding', name: 'Left Internal Iliac' },
   { id: 'Right_internal_iliac_Afbeelding', name: 'Right Internal Iliac' },
   { id: 'Left_common_femoral_Afbeelding', name: 'Left Common Femoral' },


### PR DESCRIPTION
## Summary
- correct `Right_extrnal_iliac_Afbeelding` typo in patency vesselSegments

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684087ea82408329a2a9a27878c23e6d