### PR TITLE
Add PropTypes to steps

### DIFF
--- a/src/components/steps/Step2_Patency.jsx
+++ b/src/components/steps/Step2_Patency.jsx
@@ -1,6 +1,7 @@
 // src/components/steps/Step2_Patency.jsx
 
 import React, { useState, useMemo } from 'react';
+import PropTypes from 'prop-types';
 import { __ } from '@wordpress/i18n';
 import SliderModal from '../UI/SliderModal';
 import VesselMap from '../VesselMap';
@@ -130,3 +131,16 @@ export default function Step2({ data, setData }) {
     </div>
   );
 }
+
+Step2.propTypes = {
+  data: PropTypes.shape({
+    patencySegments: PropTypes.objectOf(
+      PropTypes.shape({
+        severity: PropTypes.number,
+        length: PropTypes.number,
+        calcium: PropTypes.string,
+      })
+    ),
+  }).isRequired,
+  setData: PropTypes.func.isRequired,
+};

--- a/src/components/steps/Step5_Export.jsx
+++ b/src/components/steps/Step5_Export.jsx
@@ -1,5 +1,6 @@
 // src/components/steps/Step5_Export.jsx
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import jsPDF from 'jspdf';
@@ -72,3 +73,21 @@ export default function Step5({ data }) {
     </div>
   );
 }
+
+Step5.propTypes = {
+  data: PropTypes.shape({
+    stage: PropTypes.string,
+    wound: PropTypes.string,
+    ischemia: PropTypes.string,
+    infection: PropTypes.string,
+    patencySegments: PropTypes.objectOf(
+      PropTypes.shape({
+        severity: PropTypes.number,
+        length: PropTypes.number,
+        calcium: PropTypes.string,
+      })
+    ),
+    interventions: PropTypes.arrayOf(PropTypes.string),
+    interventionNotes: PropTypes.string,
+  }).isRequired,
+};


### PR DESCRIPTION
## Summary
- add prop type checks for Step2_Patency and Step5_Export

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6846e49d7c588329b1a67cc0ad62fa4b