### PR TITLE
Add version bump hook and update plugin header

### DIFF
--- a/endo-planner.php
+++ b/endo-planner.php
@@ -2,8 +2,8 @@
 /**
  * Plugin Name: EndoPlanner 2.0
  * Description: A Gutenberg‐based wizard for clinical indication, patency mapping, case summary, intervention planning, and PDF export.
- * Version:     2025.06.09
- * Author:      Your Name
+ * Version:     0.0.0
+ * Author:      hpebben
  * License:     GPL2+
  *
  * GitHub Plugin URI: https://github.com/hpebben/endo-planner-v2


### PR DESCRIPTION
## Summary
- set placeholder version in `endo-planner.php`
- add a pre-commit hook that bumps plugin version automatically

## Testing
- `pre-commit` (ran implicitly while committing)


------
https://chatgpt.com/codex/tasks/task_e_6846f08f384c83299da236542395a23d