### PR TITLE
Add version bump script and update plugin header

### DIFF
--- a/endo-planner.php
+++ b/endo-planner.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: EndoPlanner 2.0
  * Description: A Gutenberg‐based wizard for clinical indication, patency mapping, case summary, intervention planning, and PDF export.
- * Version:     0.0.0
+ * Version:     1.0.0
  * Author:      hpebben
  * License:     GPL2+
  *

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "license": "GPL-2.0-or-later",
   "scripts": {
     "build": "wp-scripts build",
-    "start": "wp-scripts start"
+    "start": "wp-scripts start",
+    "version": "node scripts/bump-version.js",
+    "postversion": "git add endo-planner.php && git commit -m \"chore: bump plugin version to v$npm_package_version\""
   },
   "devDependencies": {
     "@wordpress/scripts": "^24.6.0",

--- a/scripts/bump-version.js
+++ b/scripts/bump-version.js
@@ -1,0 +1,14 @@
+const fs = require('fs');
+const path = require('path');
+
+const root = path.resolve(__dirname, '..');
+const pkg = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8'));
+const version = pkg.version;
+
+const pluginPath = path.join(root, 'endo-planner.php');
+let content = fs.readFileSync(pluginPath, 'utf8');
+
+content = content.replace(/(^\s*\*\s*Version:\s*).*/m, `$1${version}`);
+content = content.replace(/(^\s*\*\s*Author:\s*).*/m, `$1hpebben`);
+
+fs.writeFileSync(pluginPath, content, 'utf8');


### PR DESCRIPTION
## Summary
- add a `scripts/bump-version.js` helper that syncs plugin headers with package.json
- run the script through npm `version` hook and commit via `postversion`
- update plugin header to version 1.0.0

## Testing
- `npm run build` *(fails: jspdf module missing)*

------
https://chatgpt.com/codex/tasks/task_e_684715d25d1c8329a6f30b33ac4f1f1e