### PR TITLE
Refactor step UI using WordPress buttons

### DIFF
--- a/src/components/steps/Step1_Clinical.jsx
+++ b/src/components/steps/Step1_Clinical.jsx
@@ -1,38 +1,28 @@
-import { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { __ } from '@wordpress/i18n';
-import IconButton from '../UI/IconButton';
+import { Button } from '@wordpress/components';
+import { useBlockProps } from '@wordpress/block-editor';
 
 const stageOptions = [
   {
     key: 'I',
     label: __( 'Asymptomatic', 'endoplanner' ),
-    icon: 'visibility',
-    tooltip: __( 'No symptoms or functional limitation.', 'endoplanner' )
   },
   {
     key: 'IIa',
     label: __( 'Intermittent Claudication IIA', 'endoplanner' ),
-    icon: 'walking',
-    tooltip: __( 'Pain-free walking distance greater than 200 m.', 'endoplanner' )
   },
   {
     key: 'IIb',
     label: __( 'Intermittent Claudication IIB', 'endoplanner' ),
-    icon: 'running',
-    tooltip: __( 'Pain occurs after walking less than 200 m.', 'endoplanner' )
   },
   {
     key: 'III',
     label: __( 'Rest Pain', 'endoplanner' ),
-    icon: 'tired',
-    tooltip: __( 'Ischemic rest pain present.', 'endoplanner' )
   },
   {
     key: 'IV',
     label: __( 'Ulcer/Gangrene', 'endoplanner' ),
-    icon: 'warning',
-    tooltip: __( 'Tissue loss with ulceration or gangrene.', 'endoplanner' )
   },
 ];
 
@@ -40,26 +30,18 @@ const woundOptions = [
   {
     key: '0',
     label: __( 'No wound', 'endoplanner' ),
-    icon: 'yes',
-    tooltip: __( 'No ulceration or gangrene', 'endoplanner' )
   },
   {
     key: '1',
     label: __( 'Small ulcer', 'endoplanner' ),
-    icon: 'universal-access-alt',
-    tooltip: __( 'Superficial ulcer < 1 cm', 'endoplanner' )
   },
   {
     key: '2',
     label: __( 'Deep ulcer', 'endoplanner' ),
-    icon: 'flag',
-    tooltip: __( 'Deeper ulcer with exposed structures', 'endoplanner' )
   },
   {
     key: '3',
     label: __( 'Extensive', 'endoplanner' ),
-    icon: 'shield',
-    tooltip: __( 'Extensive tissue loss or gangrene', 'endoplanner' )
   },
 ];
 
@@ -67,26 +49,18 @@ const ischemiaOptions = [
   {
     key: '0',
     label: __( 'None', 'endoplanner' ),
-    icon: 'yes',
-    tooltip: __( 'No ischemia', 'endoplanner' )
   },
   {
     key: '1',
     label: __( 'Mild', 'endoplanner' ),
-    icon: 'minus',
-    tooltip: __( 'Mild reduction in perfusion', 'endoplanner' )
   },
   {
     key: '2',
     label: __( 'Moderate', 'endoplanner' ),
-    icon: 'warning',
-    tooltip: __( 'Significant ischemia present', 'endoplanner' )
   },
   {
     key: '3',
     label: __( 'Severe', 'endoplanner' ),
-    icon: 'dismiss',
-    tooltip: __( 'Severe ischemia with critical findings', 'endoplanner' )
   },
 ];
 
@@ -94,30 +68,24 @@ const infectionOptions = [
   {
     key: '0',
     label: __( 'None', 'endoplanner' ),
-    icon: 'yes',
-    tooltip: __( 'No infection', 'endoplanner' )
   },
   {
     key: '1',
     label: __( 'Mild', 'endoplanner' ),
-    icon: 'minus',
-    tooltip: __( 'Local infection only', 'endoplanner' )
   },
   {
     key: '2',
     label: __( 'Moderate', 'endoplanner' ),
-    icon: 'warning',
-    tooltip: __( 'Deeper or spreading infection', 'endoplanner' )
   },
   {
     key: '3',
     label: __( 'Severe', 'endoplanner' ),
-    icon: 'dismiss',
-    tooltip: __( 'Systemic infection or sepsis', 'endoplanner' )
   },
 ];
 
 export default function Step1({ data, setData }) {
+  const blockProps = useBlockProps();
+
   const selectStage = ( key ) => {
     setData({ ...data, stage: key });
   };
@@ -135,60 +103,63 @@ export default function Step1({ data, setData }) {
   };
 
   return (
-    <Fragment>
-      <h3>{ __( 'Stage', 'endoplanner' ) }</h3>
-      <div className="step1-grid">
-        { stageOptions.map((o) =>
-          <IconButton
+    <div {...blockProps} className="clinical-indication-container">
+      <div className="step-group">
+        <h3>{ __( 'Stage', 'endoplanner' ) }</h3>
+        { stageOptions.map((o) => (
+          <Button
             key={o.key}
-            icon={o.icon}
-            label={o.label}
-            tooltip={o.tooltip}
-            isSelected={ data.stage === o.key }
+            isSecondary
+            isPressed={ data.stage === o.key }
             onClick={() => selectStage(o.key)}
-          />
-        )}
+          >
+            { o.label }
+          </Button>
+        )) }
       </div>
-      <h3>{ __( 'Wound Grade', 'endoplanner' ) }</h3>
-      <div className="step1-grid">
+
+      <div className="step-group">
+        <h3>{ __( 'Wound Grade', 'endoplanner' ) }</h3>
         { woundOptions.map((o) => (
-          <IconButton
+          <Button
             key={o.key}
-            icon={o.icon}
-            label={o.label}
-            tooltip={o.tooltip}
-            isSelected={ data.wound === o.key }
+            isSecondary
+            isPressed={ data.wound === o.key }
             onClick={() => selectWound(o.key)}
-          />
+          >
+            { o.label }
+          </Button>
         )) }
       </div>
-      <h3>{ __( 'Ischemia', 'endoplanner' ) }</h3>
-      <div className="step1-grid">
+
+      <div className="step-group">
+        <h3>{ __( 'Ischemia', 'endoplanner' ) }</h3>
         { ischemiaOptions.map((o) => (
-          <IconButton
+          <Button
             key={o.key}
-            icon={o.icon}
-            label={o.label}
-            tooltip={o.tooltip}
-            isSelected={ data.ischemia === o.key }
+            isSecondary
+            isPressed={ data.ischemia === o.key }
             onClick={() => selectIschemia(o.key)}
-          />
+          >
+            { o.label }
+          </Button>
         )) }
       </div>
-      <h3>{ __( 'Infection', 'endoplanner' ) }</h3>
-      <div className="step1-grid">
+
+      <div className="step-group">
+        <h3>{ __( 'Infection', 'endoplanner' ) }</h3>
         { infectionOptions.map((o) => (
-          <IconButton
+          <Button
             key={o.key}
-            icon={o.icon}
-            label={o.label}
-            tooltip={o.tooltip}
-            isSelected={ data.infection === o.key }
+            isSecondary
+            isPressed={ data.infection === o.key }
             onClick={() => selectInfection(o.key)}
-          />
+          >
+            { o.label }
+          </Button>
         )) }
       </div>
-    </Fragment>
+    </div>
   );
 }
 

--- a/src/components/steps/Step2_Patency.jsx
+++ b/src/components/steps/Step2_Patency.jsx
@@ -3,8 +3,10 @@
 import React, { useState, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
+import { useBlockProps } from '@wordpress/block-editor';
 import SliderModal from '../UI/SliderModal';
-import VesselMap from '../VesselMap';
+import VesselMap from '../components/VesselMap';
 
 // List every <g id="..."> exactly as it appears in the SVG
 const vesselSegments = [
@@ -43,6 +45,7 @@ const vesselSegments = [
 ];
 
 export default function Step2({ data, setData }) {
+  const blockProps = useBlockProps();
   const [modalOpen, setModalOpen] = useState(false);
   const [activeSegment, setActiveSegment] = useState(null);
   const segments = data.patencySegments || {};
@@ -85,47 +88,47 @@ export default function Step2({ data, setData }) {
   };
 
   return (
-    <div className="step2-patency">
-      <div className="vessel-map-wrapper">
-          <VesselMap
-            segmentRefs={segmentRefs}
-            segmentColors={segmentColors}
-            onSegmentClick={handleSegmentClick}
-          />
+    <div {...blockProps} className="vessel-patency-container">
+      <div className="vessel-map-container">
+        <VesselMap
+          segmentRefs={segmentRefs}
+          segmentColors={segmentColors}
+          onSegmentClick={handleSegmentClick}
+        />
+        <SliderModal
+          isOpen={modalOpen}
+          segment={activeSegment}
+          values={segments[activeSegment] || {
+            severity: 0,
+            length: 0,
+            calcium: 'none',
+          }}
+          onClose={() => setModalOpen(false)}
+          onSave={handleSave}
+        />
       </div>
-
-      <SliderModal
-        isOpen={modalOpen}
-        segment={activeSegment}
-        values={segments[activeSegment] || {
-          severity: 0,
-          length: 0,
-          calcium: 'none',
-        }}
-        onClose={() => setModalOpen(false)}
-        onSave={handleSave}
-      />
 
       <aside className="patency-summary-sidebar">
         <h4>{ __( 'Selected Vessel Data', 'endoplanner' ) }</h4>
         <ul>
           {Object.entries(segments).map(([id, vals]) => (
             <li key={id}>
-              <strong>
-                {vesselSegments.find((s) => s.id === id)?.name || id}
-              </strong>
+              <strong>{vesselSegments.find((s) => s.id === id)?.name || id}</strong>
               : {vals.severity}% stenosis, {vals.length} cm, {vals.calcium}{' '}
-              <button
+              <Button
+                isSecondary
                 onClick={() => {
                   setActiveSegment(id);
                   setModalOpen(true);
                 }}
               >
                 { __( 'Edit', 'endoplanner' ) }
-              </button>
+              </Button>
             </li>
           ))}
-          {Object.keys(segments).length === 0 && <li>{ __( 'No segments set yet.', 'endoplanner' ) }</li>}
+          {Object.keys(segments).length === 0 && (
+            <li>{ __( 'No segments set yet.', 'endoplanner' ) }</li>
+          )}
         </ul>
       </aside>
     </div>

--- a/src/styles/editor.scss
+++ b/src/styles/editor.scss
@@ -2,3 +2,46 @@
 .editor-block-list__block.is-selected .wp-block-endoplanner-v2-wizard {
   /* Add any editor‐only styles here */
 }
+
+.clinical-indication-container,
+.vessel-patency-container {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.step-group {
+  width: 100%;
+  margin-bottom: 1.5rem;
+  text-align: center;
+}
+
+.step-group h3 {
+  font-size: 1.25rem;
+  margin-bottom: 0.5rem;
+}
+
+.step-group .components-button,
+.vessel-map-container,
+.patency-summary-sidebar {
+  margin: 0.5rem;
+}
+
+.vessel-patency-container {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+}
+
+.vessel-map-container {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+}
+
+.patency-summary-sidebar {
+  width: 250px;
+}


### PR DESCRIPTION
## Summary
- swap IconButton groups for Button toggle groups in clinical step
- center clinical form with block props container
- adjust vessel patency step layout and use VesselMap component
- style new containers in editor stylesheet

## Testing
- `npm run build` *(fails: Field 'browser' doesn't contain a valid alias configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68488ebbe8f883298baba01376209e88