### PR TITLE
Improve clinical indication and vessel map UI

### DIFF
--- a/src/components/VesselMap.jsx
+++ b/src/components/VesselMap.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 export default function VesselMap({ segmentRefs = {}, segmentColors = {}, onSegmentClick = () => {} }) {
   return (
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 708.48 1484.64">
+<svg width="100%" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 708.48 1484.64">
   <defs>
     <style>{`.cls-1 { fill: none; }`}</style>
   </defs>

--- a/src/components/steps/Step1_Clinical.jsx
+++ b/src/components/steps/Step1_Clinical.jsx
@@ -103,12 +103,14 @@ export default function Step1({ data, setData }) {
   };
 
   return (
-    <div {...blockProps} className="clinical-indication-container">
+    <div className="clinical-indication-center">
+      <div {...blockProps} className="clinical-indication-container">
       <div className="step-group">
         <h3>{ __( 'Stage', 'endoplanner' ) }</h3>
         { stageOptions.map((o) => (
           <Button
             key={o.key}
+            className="step-button"
             isSecondary
             isPressed={ data.stage === o.key }
             onClick={() => selectStage(o.key)}
@@ -123,6 +125,7 @@ export default function Step1({ data, setData }) {
         { woundOptions.map((o) => (
           <Button
             key={o.key}
+            className="step-button"
             isSecondary
             isPressed={ data.wound === o.key }
             onClick={() => selectWound(o.key)}
@@ -137,6 +140,7 @@ export default function Step1({ data, setData }) {
         { ischemiaOptions.map((o) => (
           <Button
             key={o.key}
+            className="step-button"
             isSecondary
             isPressed={ data.ischemia === o.key }
             onClick={() => selectIschemia(o.key)}
@@ -151,6 +155,7 @@ export default function Step1({ data, setData }) {
         { infectionOptions.map((o) => (
           <Button
             key={o.key}
+            className="step-button"
             isSecondary
             isPressed={ data.infection === o.key }
             onClick={() => selectInfection(o.key)}
@@ -158,6 +163,7 @@ export default function Step1({ data, setData }) {
             { o.label }
           </Button>
         )) }
+      </div>
       </div>
     </div>
   );

--- a/src/components/steps/Step2_Patency.jsx
+++ b/src/components/steps/Step2_Patency.jsx
@@ -89,13 +89,14 @@ export default function Step2({ data, setData }) {
 
   return (
     <div {...blockProps} className="vessel-patency-container">
-      <div className="vessel-map-container">
+      <div className="vessel-map-center">
         <VesselMap
           segmentRefs={segmentRefs}
           segmentColors={segmentColors}
           onSegmentClick={handleSegmentClick}
         />
-        <SliderModal
+      </div>
+      <SliderModal
           isOpen={modalOpen}
           segment={activeSegment}
           values={segments[activeSegment] || {

--- a/src/styles/editor.scss
+++ b/src/styles/editor.scss
@@ -13,6 +13,11 @@
   align-items: center;
 }
 
+.clinical-indication-center {
+  display: flex;
+  justify-content: center;
+}
+
 .step-group {
   width: 100%;
   margin-bottom: 1.5rem;
@@ -24,10 +29,13 @@
   margin-bottom: 0.5rem;
 }
 
-.step-group .components-button,
-.vessel-map-container,
+.step-group .step-button {
+  margin: 0.5rem;
+}
+
 .patency-summary-sidebar {
   margin: 0.5rem;
+  width: 250px;
 }
 
 .vessel-patency-container {
@@ -36,12 +44,33 @@
   align-items: flex-start;
 }
 
-.vessel-map-container {
+.vessel-map-center {
   flex: 1;
   display: flex;
   justify-content: center;
+  margin: auto;
+  max-width: 600px;
 }
 
-.patency-summary-sidebar {
-  width: 250px;
+.step-button {
+  border-radius: 4px;
+  padding: 0.4rem 0.75rem;
+  border: 1px solid transparent;
+  background-color: #f3f3f3;
+  transition: background-color 0.2s, box-shadow 0.2s;
+}
+
+.step-button:hover {
+  background-color: #e5e5e5;
+}
+
+.step-button.is-pressed {
+  background-color: #007cba;
+  color: #fff;
+  box-shadow: inset 0 0 0 2px rgba(0,0,0,0.15);
+}
+
+.wizard-nav .components-button {
+  @extend .step-button;
+  margin: 0.5rem;
 }


### PR DESCRIPTION
## Summary
- center Step1 form using new wrapper
- highlight selected options with new `step-button` style
- center the vessel map and add width scaling for the SVG
- style wizard navigation buttons

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: webpack errors due to missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_6848961053c483298deb21630c05f8fd