### PR TITLE
Improve clinical form and vessel map interaction

### DIFF
--- a/src/components/steps/Step1_Clinical.jsx
+++ b/src/components/steps/Step1_Clinical.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import { useBlockProps } from '@wordpress/block-editor';
+import { useState } from 'react';
 
 const stageOptions = [
   {
@@ -86,25 +87,34 @@ const infectionOptions = [
 export default function Step1({ data, setData }) {
   const blockProps = useBlockProps();
 
-  const selectStage = ( key ) => {
+  const [selectedStage, setSelectedStage] = useState(data.stage || '');
+  const [selectedWound, setSelectedWound] = useState(data.wound || '');
+  const [selectedIschemia, setSelectedIschemia] = useState(data.ischemia || '');
+  const [selectedInfection, setSelectedInfection] = useState(data.infection || '');
+
+  const selectStage = (key) => {
+    setSelectedStage(key);
     setData({ ...data, stage: key });
   };
 
   const selectWound = (key) => {
+    setSelectedWound(key);
     setData({ ...data, wound: key });
   };
 
   const selectIschemia = (key) => {
+    setSelectedIschemia(key);
     setData({ ...data, ischemia: key });
   };
 
   const selectInfection = (key) => {
+    setSelectedInfection(key);
     setData({ ...data, infection: key });
   };
 
   return (
-    <div className="clinical-indication-center">
-      <div {...blockProps} className="clinical-indication-container">
+    <div className="clinical-center">
+      <div {...blockProps}>
       <div className="step-group">
         <h3>{ __( 'Stage', 'endoplanner' ) }</h3>
         { stageOptions.map((o) => (
@@ -112,7 +122,7 @@ export default function Step1({ data, setData }) {
             key={o.key}
             className="step-button"
             isSecondary
-            isPressed={ data.stage === o.key }
+            isPressed={ selectedStage === o.key }
             onClick={() => selectStage(o.key)}
           >
             { o.label }
@@ -127,7 +137,7 @@ export default function Step1({ data, setData }) {
             key={o.key}
             className="step-button"
             isSecondary
-            isPressed={ data.wound === o.key }
+            isPressed={ selectedWound === o.key }
             onClick={() => selectWound(o.key)}
           >
             { o.label }
@@ -142,7 +152,7 @@ export default function Step1({ data, setData }) {
             key={o.key}
             className="step-button"
             isSecondary
-            isPressed={ data.ischemia === o.key }
+            isPressed={ selectedIschemia === o.key }
             onClick={() => selectIschemia(o.key)}
           >
             { o.label }
@@ -157,7 +167,7 @@ export default function Step1({ data, setData }) {
             key={o.key}
             className="step-button"
             isSecondary
-            isPressed={ data.infection === o.key }
+            isPressed={ selectedInfection === o.key }
             onClick={() => selectInfection(o.key)}
           >
             { o.label }

--- a/src/components/steps/Step2_Patency.jsx
+++ b/src/components/steps/Step2_Patency.jsx
@@ -1,7 +1,7 @@
 // src/components/steps/Step2_Patency.jsx
 
-import React, { useState, useEffect } from 'react';
-import { ReactComponent as VesselMap } from '../../assets/vessel-map.svg';
+import React, { useState } from 'react';
+import VesselMap from '../VesselMap';
 import SliderModal from '../UI/SliderModal';
 import { Button } from '@wordpress/components';
 import { useBlockProps } from '@wordpress/block-editor';
@@ -48,20 +48,16 @@ export default function Step2_Patency({ data, setData }) {
   const [activeSegment, setActiveSegment] = useState(null);
   const segments = data.patencySegments || {};
 
-  useEffect(() => {
-    vesselSegments.forEach((seg) => {
-      const el = document.getElementById(seg.id);
-      if (!el) return;
-      const vals = segments[seg.id] || { severity: 0, length: 0, calcium: 'none' };
-      const color = vals.severity >= 100 ? '#d63638' : vals.severity > 0 ? '#f5a623' : '#7fc241';
-      el.setAttribute('fill', color);
-      el.style.cursor = 'pointer';
-      el.onclick = () => {
-        setActiveSegment(seg.id);
-        setModalOpen(true);
-      };
-    });
-  }, [segments]);
+  const segmentColors = vesselSegments.reduce((acc, seg) => {
+    const vals = segments[seg.id] || { severity: 0 };
+    acc[seg.id] = vals.severity >= 100 ? '#d63638' : vals.severity > 0 ? '#f5a623' : '#7fc241';
+    return acc;
+  }, {});
+
+  const handleSegmentClick = (id) => {
+    setActiveSegment(id);
+    setModalOpen(true);
+  };
 
   const handleSave = (values) => {
     setData({ ...data, patencySegments: { ...segments, [activeSegment]: values } });
@@ -72,13 +68,10 @@ export default function Step2_Patency({ data, setData }) {
   return (
     <div { ...blockProps } className="step2-patency vessel-patency-container">
       <div className="vessel-map-center">
-        <VesselMap onClick={({ target }) => {
-          const id = target.id || target.closest('path')?.id;
-          if (id) {
-            setActiveSegment(id);
-            setModalOpen(true);
-          }
-        }} />
+        <VesselMap
+          onSegmentClick={handleSegmentClick}
+          segmentColors={segmentColors}
+        />
       </div>
       <aside className="patency-summary-sidebar">
         <h4>Selected Vessel Data</h4>

--- a/src/styles/editor.scss
+++ b/src/styles/editor.scss
@@ -3,18 +3,21 @@
   /* Add any editor‐only styles here */
 }
 
-.clinical-indication-container {
-  max-width: 800px;
-  margin: 0 auto;
-  padding: 1rem;
+.clinical-center {
   display: flex;
   flex-direction: column;
   align-items: center;
+  max-width: 600px;
+  margin: 2rem auto;
 }
-
-.clinical-indication-center {
-  display: flex;
-  justify-content: center;
+.clinical-center .components-button {
+  margin: 0.5rem;
+  border-radius: 6px;
+  transition: background-color 0.2s;
+}
+.clinical-center .components-button.is-pressed {
+  background-color: #007cba;
+  color: #fff;
 }
 
 .step-group {
@@ -42,9 +45,18 @@
 }
 
 .vessel-map-center {
-  flex: 1;
   display: flex;
   justify-content: center;
+  margin: 2rem auto;
+  max-width: 800px;
+}
+.vessel-map-center svg path {
+  cursor: pointer;
+  transition: fill 0.2s, stroke 0.2s;
+}
+.vessel-map-center svg path:hover {
+  stroke: #007cba;
+  stroke-width: 2px;
 }
 
 .patency-summary-sidebar {


### PR DESCRIPTION
## Summary
- track button selections in Step1 locally and center the form
- clean up Step2 to pass segment click handlers and highlight colors
- style `.clinical-center` and `.vessel-map-center`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6849aa1ac9588329a6da47c7cd73cbc8