### PR TITLE
Fix WiFI slider marker alignment

### DIFF
--- a/src/components/steps/Step1_Clinical.jsx
+++ b/src/components/steps/Step1_Clinical.jsx
@@ -81,7 +81,7 @@ export default function Step1({ data, setData }) {
       />
       <div className="slider-markers">
         {[0, 1, 2, 3].map((n) => (
-          <span key={n}>{n}</span>
+          <span key={n} className="slider-marker">{n}</span>
         ))}
       </div>
 
@@ -100,7 +100,7 @@ export default function Step1({ data, setData }) {
       />
       <div className="slider-markers">
         {[0, 1, 2, 3].map((n) => (
-          <span key={n}>{n}</span>
+          <span key={n} className="slider-marker">{n}</span>
         ))}
       </div>
 
@@ -119,7 +119,7 @@ export default function Step1({ data, setData }) {
       />
       <div className="slider-markers">
         {[0, 1, 2, 3].map((n) => (
-          <span key={n}>{n}</span>
+          <span key={n} className="slider-marker">{n}</span>
         ))}
       </div>
 

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -183,12 +183,20 @@ svg path:hover {
     margin-top: -5px;
 }
 .slider-markers {
-    display: flex;
-    justify-content: space-between;
-    font-size: 0.85rem;
-    color: #333;
-    margin-bottom: 1rem;
+    position: relative;
+    width: 100%;
+    height: 1rem;
+    margin-bottom: 2rem;
 }
+.slider-marker {
+    position: absolute;
+    top: 0;
+    transform: translateX(-50%);
+}
+.slider-marker:nth-child(1) { left: 0%; }
+.slider-marker:nth-child(2) { left: 33.333%; }
+.slider-marker:nth-child(3) { left: 66.666%; }
+.slider-marker:nth-child(4) { left: 100%; }
 .section-spacer {
     height: 2rem;
 }


### PR DESCRIPTION
## Summary
- use absolute positioning for WiFI slider markers
- add `.slider-marker` spans in clinical step UI
- style markers to align below each slider stop

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684deec9ca348329a0f55265f88acb91