### PR TITLE
Add debug logging for SVG interactions

### DIFF
--- a/src/components/VesselMap.jsx
+++ b/src/components/VesselMap.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { ReactComponent as MapSvg } from '../assets/vessel-map.svg';
 import { vesselSegments } from './steps/Step2_Patency';
 
@@ -7,11 +7,17 @@ export default function VesselMap({
   toggleSegment = () => {},
   setTooltip = () => {},
 }) {
+  const [hoverSegment, setHoverSegment] = useState(null);
+
+  console.log('VesselMap state', { hoverSegment, selectedSegments });
 
   useEffect(() => {
     const handlers = [];
     vesselSegments.forEach(({ id, name }) => {
       const group = document.getElementById(id);
+      if (group) {
+        console.log(`Found SVG element: ${id}`);
+      }
       if (!group) return;
       group.querySelectorAll('path').forEach((el) => {
         el.classList.add('segment');
@@ -26,12 +32,25 @@ export default function VesselMap({
           el.appendChild(t);
         }
 
-        const clickHandler = () => toggleSegment(id);
-        const enterHandler = (e) =>
+        const clickHandler = () => {
+          const newSelected = selectedSegments.includes(id)
+            ? selectedSegments.filter((s) => s !== id)
+            : [...selectedSegments, id];
+          console.log('clicked: ' + id, newSelected);
+          toggleSegment(id);
+        };
+        const enterHandler = (e) => {
+          console.log('hover start: ' + id, e.clientX, e.clientY);
+          setHoverSegment(id);
           setTooltip({ name, x: e.clientX, y: e.clientY });
+        };
         const moveHandler = (e) =>
           setTooltip({ name, x: e.clientX, y: e.clientY });
-        const leaveHandler = () => setTooltip(null);
+        const leaveHandler = () => {
+          console.log('hover end: ' + id);
+          setHoverSegment(null);
+          setTooltip(null);
+        };
 
         el.addEventListener('click', clickHandler);
         el.addEventListener('mouseenter', enterHandler);

--- a/src/components/steps/Step2_Patency.jsx
+++ b/src/components/steps/Step2_Patency.jsx
@@ -99,6 +99,7 @@ export default function Step2_Patency({ data, setData }) {
           ) : (
             __('No segments selected.', 'endoplanner')
           )}
+          <pre>{JSON.stringify(selectedSegments, null, 2)}</pre>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- instrument `VesselMap` with console logs for SVG segments, hover, and clicks
- output current `hoverSegment` and `selectedSegments` state each render
- show `selectedSegments` list as JSON in the patency summary box

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685050867be48329bf47cf2bebf2c1f3