### PR TITLE
Add missing vessel segments and logging

### DIFF
--- a/src/components/VesselMap.jsx
+++ b/src/components/VesselMap.jsx
@@ -13,11 +13,12 @@ export default function VesselMap({
 
   useEffect(() => {
     const handlers = [];
+    let found = 0,
+      missing = [];
     vesselSegments.forEach(({ id, name }) => {
       const group = document.getElementById(id);
-      if (group) {
-        console.log(`Found SVG element: ${id}`);
-      }
+      if (group) found++;
+      else missing.push(id);
       if (!group) return;
       group.querySelectorAll('path').forEach((el) => {
         el.classList.add('segment');
@@ -59,6 +60,8 @@ export default function VesselMap({
         handlers.push({ el, clickHandler, enterHandler, moveHandler, leaveHandler });
       });
     });
+    console.warn(`🔍 Found ${found}/${vesselSegments.length} segments.`);
+    if (missing.length) console.warn('❌ Missing SVG IDs:', missing);
     return () => {
       handlers.forEach(({ el, clickHandler, enterHandler, moveHandler, leaveHandler }) => {
         el.removeEventListener('click', clickHandler);

--- a/src/components/steps/Step2_Patency.jsx
+++ b/src/components/steps/Step2_Patency.jsx
@@ -30,16 +30,21 @@ const vesselSegments = [
   { id: 'Right_peroneal_Afbeelding', name: 'Right Peroneal' },
   { id: 'Left_posterior_tibial2_Afbeelding', name: 'Left Posterior Tibial' },
   { id: 'Right_posterior_tibial_Afbeelding', name: 'Right Posterior Tibial' },
+  { id: 'Left_tibioperoneal_trunk_Afbeelding', name: 'Left Tibioperoneal Trunk' },
+  { id: 'Right_tibioperoneal_trunk_Afbeelding', name: 'Right Tibioperoneal Trunk' },
   { id: 'crural_Afbeelding', name: 'Crural Trunk' },
   { id: 'Left_dorsal_pedal_Afbeelding', name: 'Left Dorsal Pedal' },
   { id: 'Right_dorsal_pedal_Afbeelding', name: 'Right Dorsal Pedal' },
   { id: 'Left_medial_plantar_Afbeelding', name: 'Left Medial Plantar' },
   { id: 'Left_lateral_plantar_Afbeelding', name: 'Left Lateral Plantar' },
+  { id: 'Right_medial_plantar_Afbeelding', name: 'Right Medial Plantar' },
+  { id: 'Right_lateral_plantar_Afbeelding', name: 'Right Lateral Plantar' },
   { id: 'Left_plantar_arch_Afbeelding', name: 'Left Plantar Arch' },
   { id: 'Right_plantar_arch_Afbeelding', name: 'Right Plantar Arch' },
   { id: 'Left_metatarsal_Afbeelding', name: 'Left Metatarsal' },
   { id: 'Right_metatarsal_Afbeelding', name: 'Right Metatarsal' },
   { id: 'pedal_Afbeelding', name: 'Pedal Vessel' },
+  { id: 'fem-pop_Afbeelding', name: 'Fem-Pop' },
 ];
 
 


### PR DESCRIPTION
## Summary
- add aggregate logging of found/missing SVG ids
- include previously missing segments in vesselSegments list

## Testing
- `npm run build` *(fails: wp-scripts not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6850668559688329a84238642b28a893