### PR TITLE
Handle nested vessel segments

### DIFF
--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -273,14 +273,7 @@ svg path:hover {
 .vessel-container {
   position: relative;
 }
-.vessel-map-wrapper svg defs {
-  pattern#stripePattern {
-    patternUnits: userSpaceOnUse;
-    width: 6;
-    height: 6;
-  }
-}
-.vessel-map-wrapper svg .highlighted {
+.vessel-map-wrapper svg path.selected {
   fill: url(#stripePattern) !important;
   transition: fill 0.2s;
 }


### PR DESCRIPTION
## Summary
- traverse all svg elements with id ending in `_Afbeelding`
- inject stripe pattern in svg `<defs>`
- attach hover/click handlers to each sub-element
- log hovered and selected segment ids
- only highlight selected paths

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: wp-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852b16eea308329ac366002b9fcd17f