### PR TITLE
Improve vessel map interactions

### DIFF
--- a/src/components/VesselMap.jsx
+++ b/src/components/VesselMap.jsx
@@ -9,8 +9,6 @@ export default function VesselMap({
 }) {
   const [hoverSegment, setHoverSegment] = useState(null);
 
-  console.log('🐭 hover:', hoverSegment, '🖱️ selected:', selectedSegments);
-
   useEffect(() => {
     const svgRoot = document.querySelector('.vessel-map-wrapper svg');
 
@@ -30,9 +28,9 @@ export default function VesselMap({
       `;
     }
 
-    const rawEls = svgRoot.querySelectorAll('[id$="_Afbeelding"]');
-    const segments = Array.from(rawEls).map((el) => ({ id: el.id.split('__').pop(), el }));
-    console.log('🔍 Found IDs:', segments.map((s) => s.id));
+    const allEls = svgRoot.querySelectorAll('[id$="_Afbeelding"]');
+    const leafEls = Array.from(allEls).filter((el) => el.children.length === 0);
+    const segments = leafEls.map((el) => ({ id: el.id.split('__').pop(), el }));
 
     const handlers = [];
 
@@ -55,11 +53,13 @@ export default function VesselMap({
         el.classList.toggle('selected');
       };
       const enterHandler = (e) => {
+        el.classList.add('hovered');
         setHoverSegment(id);
         setTooltip({ name, x: e.clientX, y: e.clientY });
       };
       const moveHandler = (e) => setTooltip({ name, x: e.clientX, y: e.clientY });
       const leaveHandler = () => {
+        el.classList.remove('hovered');
         setHoverSegment(null);
         setTooltip(null);
       };

--- a/src/components/steps/Step2_Patency.jsx
+++ b/src/components/steps/Step2_Patency.jsx
@@ -54,9 +54,6 @@ export default function Step2_Patency({ data, setData }) {
   const blockProps = useBlockProps();
   const [tooltip, setTooltip] = useState(null);
   const selectedSegments = Object.keys(data.patencySegments || {});
-  const selectedNames = selectedSegments.map(
-    (id) => vesselSegments.find((s) => s.id === id)?.name || id
-  );
 
   const toggleSegment = (id) => {
     setData((prev) => {
@@ -95,16 +92,15 @@ export default function Step2_Patency({ data, setData }) {
           )}
         </div>
         <div className="summary-box">
-          {selectedNames.length ? (
-            <ul>
-              {selectedNames.map((n) => (
-                <li key={n}>{n}</li>
+          {selectedSegments.length ? (
+            <ul className="vessel-summary">
+              {selectedSegments.map((id) => (
+                <li key={id}>{id.replace(/_/g, ' ').replace('Afbeelding', '')}</li>
               ))}
             </ul>
           ) : (
             __('No segments selected.', 'endoplanner')
           )}
-          <pre>{JSON.stringify(selectedSegments, null, 2)}</pre>
         </div>
       </div>
     </div>

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -273,9 +273,14 @@ svg path:hover {
 .vessel-container {
   position: relative;
 }
+.vessel-map-wrapper svg path.hovered {
+  stroke: #007cba !important;
+  stroke-width: 4 !important;
+}
 .vessel-map-wrapper svg path.selected {
-  fill: url(#stripePattern) !important;
-  transition: fill 0.2s;
+  stroke: #cc0000 !important;
+  stroke-width: 4 !important;
+  fill: none !important;
 }
 .vessel-tooltip {
   position: fixed;
@@ -298,4 +303,12 @@ svg path:hover {
   border: 1px solid #ddd;
   border-radius: 0.25rem;
   min-width: 12rem;
+}
+
+ul.vessel-summary {
+  list-style: disc inside;
+  padding: 0.5em;
+  li {
+    margin: 0.3em 0;
+  }
 }


### PR DESCRIPTION
## Summary
- make only leaf SVG paths interactive
- highlight hovered segments in blue
- toggle red outline on click
- clean bullet list of selected segments
- add styles for hover/selection and summary list

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6852be8bf1d08329945f08fd355664c5