### PR TITLE
Fix VesselMap shape wiring

### DIFF
--- a/src/assets/vessel-map.svg
+++ b/src/assets/vessel-map.svg
@@ -5,7 +5,10 @@
       .cls-1 {
         fill: none;
       }
-    </style>
+  </style>
+  <pattern id="stripePattern" patternUnits="userSpaceOnUse" width="8" height="8" patternTransform="rotate(45)">
+    <rect width="4" height="8" fill="rgba(208,0,0,0.3)" />
+  </pattern>
   </defs>
   <g id="pedal_Afbeelding" data-name="pedal Afbeelding">
     <g>

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -5,15 +5,19 @@
     gap: 1rem;
 }
 
-.vessel-map-wrapper path.selected-segment {
-  stroke: red !important;
+.vessel-map-wrapper path.selected-segment,
+.vessel-map-wrapper polyline.selected-segment,
+.vessel-map-wrapper polygon.selected-segment {
+  stroke: #d00000 !important;
   stroke-width: 3 !important;
   fill: url(#stripePattern) !important;
 }
 
-.vessel-map-wrapper path:hover {
+.vessel-map-wrapper path:hover,
+.vessel-map-wrapper polyline:hover,
+.vessel-map-wrapper polygon:hover {
   cursor: pointer;
-  stroke: blue !important;
+  stroke: #005fcc;
   stroke-width: 2 !important;
 }
 
@@ -307,14 +311,18 @@ svg path:hover {
   }
 }
 
-.vessel-map-wrapper path.selected-segment {
-  stroke: red !important;
+.vessel-map-wrapper path.selected-segment,
+.vessel-map-wrapper polyline.selected-segment,
+.vessel-map-wrapper polygon.selected-segment {
+  stroke: #d00000 !important;
   stroke-width: 3 !important;
   fill: url(#stripePattern) !important;
 }
 
-.vessel-map-wrapper path:hover {
+.vessel-map-wrapper path:hover,
+.vessel-map-wrapper polyline:hover,
+.vessel-map-wrapper polygon:hover {
   cursor: pointer;
-  stroke: blue !important;
+  stroke: #005fcc;
   stroke-width: 2 !important;
 }


### PR DESCRIPTION
## Summary
- wire SVG shapes by group IDs instead of paths
- log hover/selected segment state
- show debug overlay with counts
- add highlight styles for polyline and polygon shapes
- embed stripePattern in SVG

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: wp-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852fef3a6c48329a61b0ce93c3cb9fd