### PR TITLE
Improve vessel map hover and layout

### DIFF
--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -5,20 +5,49 @@
     gap: 1rem;
 }
 
-.vessel-map-wrapper path.selected-segment,
-.vessel-map-wrapper polyline.selected-segment,
-.vessel-map-wrapper polygon.selected-segment {
+.vessel-map-wrapper path.selected,
+.vessel-map-wrapper polyline.selected,
+.vessel-map-wrapper polygon.selected {
   stroke: #d00000 !important;
   stroke-width: 3 !important;
-  fill: url(#stripePattern) !important;
+  fill: url(#diagonal-stripe);
 }
 
-.vessel-map-wrapper path:hover,
-.vessel-map-wrapper polyline:hover,
-.vessel-map-wrapper polygon:hover {
+.vessel-map-wrapper path.hovered,
+.vessel-map-wrapper polyline.hovered,
+.vessel-map-wrapper polygon.hovered {
   cursor: pointer;
-  stroke: #005fcc;
+  stroke: blue;
   stroke-width: 2 !important;
+}
+
+/* Vessel map layout tweaks */
+.vessel-map-wrapper {
+  display: flex;
+  gap: 2rem;
+  align-items: flex-start;
+  position: relative;
+}
+.selected-segments {
+  width: 200px;
+}
+.vessel-tooltip {
+  position: absolute;
+  background: #fff;
+  border: 1px solid #ccc;
+  padding: .25em .5em;
+  border-radius: 3px;
+  pointer-events: none;
+  transform: translate(-50%, -100%);
+}
+svg path.hovered {
+  stroke: blue;
+  stroke-width: 2;
+}
+svg path.selected {
+  stroke: red;
+  stroke-width: 2;
+  fill: url(#diagonal-stripe);
 }
 
 
@@ -260,7 +289,7 @@ svg path:hover {
   /* Patency map summary panel & hover labels */
   .vessel-map-wrapper {
     position: relative;
-    pointer-events: none;
+    pointer-events: auto;
 
     svg {
       position: relative;
@@ -268,61 +297,33 @@ svg path:hover {
       pointer-events: all;
     }
 
-    path:hover {
+    path.hovered {
       cursor: pointer;
       stroke: blue !important;
       stroke-width: 2 !important;
     }
 
-    path.selected-segment {
+    path.selected {
       stroke: red !important;
       stroke-width: 3 !important;
-      fill: url(#stripePattern) !important;
+      fill: url(#diagonal-stripe);
     }
 
-    .vessel-summary {
-      position: absolute;
-      top: 0;
-      right: 0;
-      margin: 1em;
-      padding: 1em;
-      background: #fff;
-      border-radius: 4px;
-      box-shadow: 0 0 6px rgba(0,0,0,0.1);
-      pointer-events: auto;
-
-      ul {
-        list-style: disc inside;
-        margin: 0;
-        padding: 0;
-
-        li {
-          margin: 0.3em 0;
-          font-size: 0.95em;
-        }
-      }
-
-      p {
-        margin: 0;
-        font-style: italic;
-        color: #666;
-      }
-    }
   }
 }
 
-.vessel-map-wrapper path.selected-segment,
-.vessel-map-wrapper polyline.selected-segment,
-.vessel-map-wrapper polygon.selected-segment {
+.vessel-map-wrapper path.selected,
+.vessel-map-wrapper polyline.selected,
+.vessel-map-wrapper polygon.selected {
   stroke: #d00000 !important;
   stroke-width: 3 !important;
-  fill: url(#stripePattern) !important;
+  fill: url(#diagonal-stripe);
 }
 
-.vessel-map-wrapper path:hover,
-.vessel-map-wrapper polyline:hover,
-.vessel-map-wrapper polygon:hover {
+.vessel-map-wrapper path.hovered,
+.vessel-map-wrapper polyline.hovered,
+.vessel-map-wrapper polygon.hovered {
   cursor: pointer;
-  stroke: #005fcc;
+  stroke: blue;
   stroke-width: 2 !important;
 }


### PR DESCRIPTION
## Summary
- tweak vessel list and remove stray iliac entry
- wire SVG paths for hover & click with tooltip positioning
- show selected vessels in side panel
- update map styles for flex layout and new tooltip/segment classes

## Testing
- `npm run build` *(fails: wp-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68530fe1e63083299bfb027ffc4b903e