### PR TITLE
Fix block.json path for EndoPlanner block

### DIFF
--- a/build/block.json
+++ b/build/block.json
@@ -1,0 +1,10 @@
+{
+  "apiVersion": 2,
+  "name": "endoplanner/v2-wizard",
+  "title": "EndoPlanner Wizard",
+  "category": "widgets",
+  "icon": "smiley",
+  "editorScript": "file:./index.js",
+  "editorStyle":  "file:./index.css",
+  "style":        "file:./style-index.css"
+}

--- a/endo-planner.php
+++ b/endo-planner.php
@@ -9,5 +9,6 @@
 
 // Let WP auto-register everything based on block.json + build/ assets:
 add_action( 'init', function() {
+    // block.json now resides in the build directory
     register_block_type( __DIR__ . '/build' );
 } );

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "license": "GPL-2.0-or-later",
   "scripts": {
     "build": "wp-scripts build",
+    "postbuild": "cp block.json build/ || true",
     "start": "wp-scripts start",
     "version": "node scripts/bump-version.js",
     "postversion": "git add endo-planner.php && git commit -m \"chore: bump plugin version to v$npm_package_version\""


### PR DESCRIPTION
## Summary
- move block.json into the build folder
- ensure PHP registers the block from `build`
- copy block.json into `build/` on every build

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68569931b9508329b65461ed6c7b2eaf