### PR TITLE
Fix front-end loading for wizard block

### DIFF
--- a/block.json
+++ b/block.json
@@ -6,5 +6,6 @@
   "icon": "smiley",
   "editorScript": "file:./index.js",
   "editorStyle":  "file:./index.css",
-  "style":        "file:./style-index.css"
+  "style":        "file:./style-index.css",
+  "script":       "file:./index.js"
 }

--- a/build/block.json
+++ b/build/block.json
@@ -6,5 +6,6 @@
   "icon": "smiley",
   "editorScript": "file:./index.js",
   "editorStyle":  "file:./index.css",
-  "style":        "file:./style-index.css"
+  "style":        "file:./style-index.css",
+  "script":       "file:./index.js"
 }

--- a/endo-planner.php
+++ b/endo-planner.php
@@ -8,7 +8,14 @@
  */
 
 // Let WP auto-register everything based on block.json + build/ assets:
+function endoplanner_v2_render_block( $attributes, $content, $block ) {
+    $wrapper_attributes = get_block_wrapper_attributes();
+    return '<div ' . $wrapper_attributes . '><div class="endoplanner-root"></div></div>';
+}
+
 add_action( 'init', function() {
     // block.json now resides in the build directory
-    register_block_type( __DIR__ . '/build' );
+    register_block_type( __DIR__ . '/build', array(
+        'render_callback' => 'endoplanner_v2_render_block',
+    ) );
 } );


### PR DESCRIPTION
## Summary
- ensure block.json copies to build with script field so index.js loads on front-end
- register block with render callback that outputs the hydration root

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6856a2b4fcdc83298f6e9127e29db077