### PR TITLE
Fix vessel map event handling and add debugging

### DIFF
--- a/src/components/VesselMap.jsx
+++ b/src/components/VesselMap.jsx
@@ -13,7 +13,9 @@ export default function VesselMap({
 
   useEffect(() => {
     if (hoverSegment) {
-      console.log('hover', hoverSegment);
+      console.log('Hovering segment:', hoverSegment);
+    } else {
+      console.log('Hover cleared');
     }
   }, [hoverSegment]);
 
@@ -29,17 +31,18 @@ export default function VesselMap({
         .replace(/\u00A0?Afbeelding/, '')
         .replace(/_/g, ' ')
         .trim();
+
       const shapes = Array.from(
         group.querySelectorAll('path, polyline, polygon')
       );
 
       const enter = (e) => {
+        console.log('hover event for', id, name);
         setHoverSegment(id);
         if (setTooltip) {
           const rect = e.target.getBoundingClientRect();
           setTooltip({ name, x: e.clientX, y: rect.top + window.scrollY });
         }
-        console.log('hover', id, name);
       };
 
       const leave = () => {
@@ -48,27 +51,27 @@ export default function VesselMap({
       };
 
       const click = () => {
+        console.log('click event for', id, name);
         toggleSegment(id);
-        console.log('click', id, name);
       };
+
+      console.log('Attaching handlers to', id);
+      group.addEventListener('mouseover', enter);
+      group.addEventListener('mouseout', leave);
+      group.addEventListener('click', click);
 
       shapes.forEach((shape) => {
         shape.classList.add('vessel-path');
-        shape.addEventListener('mouseenter', enter);
-        shape.addEventListener('mouseleave', leave);
-        shape.addEventListener('click', click);
       });
 
-      return { id, name, shapes, handlers: { enter, leave, click } };
+      return { id, name, shapes, el: group, handlers: { enter, leave, click } };
     });
 
     return () => {
-      segmentsRef.current.forEach(({ shapes, handlers }) => {
-        shapes.forEach((shape) => {
-          shape.removeEventListener('mouseenter', handlers.enter);
-          shape.removeEventListener('mouseleave', handlers.leave);
-          shape.removeEventListener('click', handlers.click);
-        });
+      segmentsRef.current.forEach(({ el, handlers }) => {
+        el.removeEventListener('mouseover', handlers.enter);
+        el.removeEventListener('mouseout', handlers.leave);
+        el.removeEventListener('click', handlers.click);
       });
       segmentsRef.current = [];
     };
@@ -81,6 +84,11 @@ export default function VesselMap({
       shapes.forEach((shape) => {
         shape.classList.toggle('selected', isSelected);
         shape.classList.toggle('hovered', isHover);
+        console.log(
+          'Apply classes for',
+          id,
+          shape.getAttribute('class')
+        );
       });
     });
   }, [selectedSegments, hoverSegment]);

--- a/src/components/steps/Step2_Patency.jsx
+++ b/src/components/steps/Step2_Patency.jsx
@@ -1,6 +1,6 @@
 // src/components/steps/Step2_Patency.jsx
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import VesselMap from '../VesselMap';
 import { useBlockProps } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
@@ -54,6 +54,14 @@ export default function Step2_Patency({ data, setData }) {
   const blockProps = useBlockProps();
   const [tooltip, setTooltip] = useState(null);
   const selectedSegments = Object.keys(data.patencySegments || {});
+
+  useEffect(() => {
+    if (tooltip) {
+      console.log('Render tooltip for', tooltip.name, tooltip);
+    } else {
+      console.log('Tooltip cleared');
+    }
+  }, [tooltip]);
 
   const toggleSegment = (id) => {
     setData((prev) => {


### PR DESCRIPTION
## Summary
- add extensive console debugging around vessel map events
- attach hover/click handlers to each vessel `<g>` group
- log tooltip activity in Step2 component
- highlight classes after every state update

## Testing
- `npm run build` *(fails: wp-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856b347ff608329b20e809d434abd2d