### PR TITLE
Ensure transparent rects in vessel map

### DIFF
--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -12,6 +12,9 @@
   flex: 1;
   max-width: 600px;
   width: 100%;
+  rect {
+    fill: none !important;
+  }
 }
 .vessel-path {
   cursor: pointer;


### PR DESCRIPTION
## Summary
- enforce transparent background for any `<rect>` elements inside the vessel map

## Testing
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_6856bc5e9870832998f6c1034e164ab3