### PR TITLE
Fix black background in SVG

### DIFF
--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -19,6 +19,7 @@
 .vessel-path {
   cursor: pointer;
   transition: stroke 0.2s;
+  fill: none; // ensure paths don't default to black fill
 }
 .vessel-path.hovered {
   stroke: #0073e6 !important;
@@ -315,4 +316,8 @@ svg path:hover {
     }
 
   }
+
+.pedal-section, .pedal-section * {
+    background: transparent !important;
+    fill: none !important;
 }


### PR DESCRIPTION
## Summary
- avoid default black fill on vessel path segments
- enforce transparent backgrounds for pedal section

## Testing
- `npm run build` *(fails: wp-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856c0a64e14832990f39a011f534c1c