### PR TITLE
Fix SCSS unclosed block

### DIFF
--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -317,6 +317,8 @@ svg path:hover {
 
   }
 
+}
+
 .pedal-section, .pedal-section * {
     background: transparent !important;
     fill: none !important;


### PR DESCRIPTION
## Summary
- close `.wp-block-endoplanner-v2-wizard` block in `style.scss`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6856c30dd5d88329a26d0ff49861c76d