### PR TITLE
Fix wizard mount timing

### DIFF
--- a/src/frontend.js
+++ b/src/frontend.js
@@ -2,8 +2,17 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import Wizard from './components/wizard';
 
-document.addEventListener('DOMContentLoaded', () => {
+// Mount the React wizard once the DOM is ready. In some cases the script
+// is loaded after the DOMContentLoaded event has already fired, so check the
+// current readyState and call the mount function immediately when possible.
+const mount = () => {
   document.querySelectorAll('.endoplanner-root').forEach((container) => {
     ReactDOM.render(<Wizard />, container);
   });
-});
+};
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', mount);
+} else {
+  mount();
+}


### PR DESCRIPTION
## Summary
- mount React wizard immediately if DOM is already ready

## Testing
- `npm run build` *(fails: wp-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856c6c14a4883299fb9e216d78e2423