### PR TITLE
Improve vessel tooltip positioning

### DIFF
--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -135,7 +135,14 @@
   pointer-events: none;
   white-space: nowrap;
   font-size: 0.75rem;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.3);
+  opacity: 0;
   transition: opacity 0.2s;
+  z-index: 10;
+}
+
+.vessel-tooltip.visible {
+  opacity: 1;
 }
 
 .vessel-tooltip.right {


### PR DESCRIPTION
## Summary
- position tooltips dynamically relative to vessel segments
- flip tooltip sides to avoid container overflow
- fade tooltips in and out on hover
- style tooltip with shadow and opacity transition

## Testing
- `npm run build` *(fails: wp-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68603a1d85bc832982f0c706e5de76f1