### PR TITLE
Align intervention device columns

### DIFF
--- a/src/components/steps/Step4_Intervention.jsx
+++ b/src/components/steps/Step4_Intervention.jsx
@@ -651,76 +651,96 @@ function AccessRow({ index, values, onChange, onAdd, onRemove, showRemove }) {
           onChange={(val) => { console.log('Access approach', val); onChange({ ...data, approach: val }); }}
         />
         </div>
-        <div className="device-row">
-        <DeviceButton
-          label={vesselLabel}
-          img={vesselTreeIcon}
-          onClick={(e) => {
-            console.log('Open vessel modal', index);
-            setVesselAnchor(e.currentTarget.getBoundingClientRect());
-            setVesselOpen(true);
-          }}
-        />
-        </div>
-        <div className="device-row">
-          {needles.map((n, i) => (
-            <div key={`n${i}`} className="device-row-wrapper">
-              <DeviceButton
-                label={shortLabel('needle', n) || __('choose needle', 'endoplanner')}
-                img={needleImg}
-                onClick={(e) => {
-                  console.log('Open needle modal', index, i);
-                  setNeedleIdx(i);
-                  setNeedleAnchor(e.currentTarget.getBoundingClientRect());
-                  setNeedleOpen(true);
-                }}
-              />
-              {i > 0 && (
-                <button type="button" className="device-inline-btn remove-btn" onClick={() => removeNeedle(i)}>&minus;</button>
-              )}
-              <button type="button" className="device-inline-btn add-btn" onClick={addNeedle}>+</button>
-            </div>
-          ))}
-        </div>
-        <div className="device-row">
-          {sheaths.map((s, i) => (
-            <div key={`s${i}`} className="device-row-wrapper">
-              <DeviceButton
-                label={shortLabel('sheath', s) || __('choose sheath', 'endoplanner')}
-                img={sheathImg}
-                onClick={(e) => {
-                  console.log('Open sheath modal', index, i);
-                  setSheathIdx(i);
-                  setSheathAnchor(e.currentTarget.getBoundingClientRect());
-                  setSheathOpen(true);
-                }}
-              />
-              {i > 0 && (
-                <button type="button" className="device-inline-btn remove-btn" onClick={() => removeSheath(i)}>&minus;</button>
-              )}
-              <button type="button" className="device-inline-btn add-btn" onClick={addSheath}>+</button>
-            </div>
-          ))}
-        </div>
-        <div className="device-row">
-          {catheters.map((c, i) => (
-            <div key={`c${i}`} className="device-row-wrapper">
-              <DeviceButton
-                label={shortLabel('catheter', c) || __('choose catheter', 'endoplanner')}
-                img={catheterImg}
-                onClick={(e) => {
-                  console.log('Open catheter modal', index, i);
-                  setCatIdx(i);
-                  setCatAnchor(e.currentTarget.getBoundingClientRect());
-                  setCatOpen(true);
-                }}
-              />
-              {i > 0 && (
-                <button type="button" className="device-inline-btn remove-btn" onClick={() => removeCatheter(i)}>&minus;</button>
-              )}
-              <button type="button" className="device-inline-btn add-btn" onClick={addCatheter}>+</button>
-            </div>
-          ))}
+        <div className="device-grid">
+          <div className="device-column">
+            <DeviceButton
+              label={vesselLabel}
+              img={vesselTreeIcon}
+              onClick={(e) => {
+                console.log('Open vessel modal', index);
+                setVesselAnchor(e.currentTarget.getBoundingClientRect());
+                setVesselOpen(true);
+              }}
+            />
+          </div>
+          <div className="device-column">
+            {needles.map((n, i) => (
+              <div key={`n${i}`} className="device-wrapper">
+                <DeviceButton
+                  label={shortLabel('needle', n) || __('choose needle', 'endoplanner')}
+                  img={needleImg}
+                  onClick={(e) => {
+                    console.log('Open needle modal', index, i);
+                    setNeedleIdx(i);
+                    setNeedleAnchor(e.currentTarget.getBoundingClientRect());
+                    setNeedleOpen(true);
+                  }}
+                />
+                <div className="device-controls">
+                  {i > 0 && (
+                    <button type="button" className="device-inline-btn remove-btn" onClick={() => removeNeedle(i)}>
+                      &minus;
+                    </button>
+                  )}
+                  <button type="button" className="device-inline-btn add-btn" onClick={addNeedle}>
+                    +
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+          <div className="device-column">
+            {sheaths.map((s, i) => (
+              <div key={`s${i}`} className="device-wrapper">
+                <DeviceButton
+                  label={shortLabel('sheath', s) || __('choose sheath', 'endoplanner')}
+                  img={sheathImg}
+                  onClick={(e) => {
+                    console.log('Open sheath modal', index, i);
+                    setSheathIdx(i);
+                    setSheathAnchor(e.currentTarget.getBoundingClientRect());
+                    setSheathOpen(true);
+                  }}
+                />
+                <div className="device-controls">
+                  {i > 0 && (
+                    <button type="button" className="device-inline-btn remove-btn" onClick={() => removeSheath(i)}>
+                      &minus;
+                    </button>
+                  )}
+                  <button type="button" className="device-inline-btn add-btn" onClick={addSheath}>
+                    +
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+          <div className="device-column">
+            {catheters.map((c, i) => (
+              <div key={`c${i}`} className="device-wrapper">
+                <DeviceButton
+                  label={shortLabel('catheter', c) || __('choose catheter', 'endoplanner')}
+                  img={catheterImg}
+                  onClick={(e) => {
+                    console.log('Open catheter modal', index, i);
+                    setCatIdx(i);
+                    setCatAnchor(e.currentTarget.getBoundingClientRect());
+                    setCatOpen(true);
+                  }}
+                />
+                <div className="device-controls">
+                  {i > 0 && (
+                    <button type="button" className="device-inline-btn remove-btn" onClick={() => removeCatheter(i)}>
+                      &minus;
+                    </button>
+                  )}
+                  <button type="button" className="device-inline-btn add-btn" onClick={addCatheter}>
+                    +
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
         </div>
         <RowControls onAdd={onAdd} onRemove={onRemove} showRemove={showRemove} />
         <VesselDropdown

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -657,31 +657,32 @@ svg .vessel-path:hover {
   width: 100%;
 }
 
-.device-row-wrapper {
-  /* wrap each device button so +/− controls can be positioned over it */
-  position: relative;
-  display: inline-flex;
-  margin: 0 0.5rem 1.5rem;
-}
-
-.add-device-btn {
-  position: absolute;
-  right: 0;
-  bottom: -14px;
-  width: 28px;
-  height: 28px;
-  border-radius: 50%;
-  background: #113195;
-  color: #fff;
-  border: none;
+// layout holding one column per device type
+.device-grid {
   display: flex;
-  align-items: center;
   justify-content: center;
-  cursor: pointer;
-  box-shadow: 0 2px 6px rgba(0,0,0,0.2);
+  gap: 1rem;
+  width: 100%;
+  flex-wrap: nowrap;
 }
 
-/* small inline add/remove controls placed at bottom-right of each selector */
+
+// container for a column of device selectors (e.g. all needles)
+.device-column {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+// wrapper around each individual selector so controls sit below
+.device-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+}
+
+/* small inline add/remove controls placed below each selector */
 .device-inline-btn {
   width: 22px; /* smaller than main selector */
   height: 22px;
@@ -694,13 +695,14 @@ svg .vessel-path:hover {
   justify-content: center;
   cursor: pointer;
   box-shadow: 0 2px 4px rgba(0,0,0,0.2);
-  position: absolute;
-  bottom: -10px;
-  right: 0;
   font-size: 12px;
 }
-.device-inline-btn.remove-btn {
-  right: 26px;
+.device-controls {
+  display: flex;
+  gap: 4px;
+  justify-content: flex-end;
+  width: 100%;
+  margin-top: 4px;
 }
 
 .device-button {


### PR DESCRIPTION
## Summary
- refactor Access row device layout into columns
- add flex grid styles so device types line up in one row
- move add/remove buttons below each selector

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6865926ba6a08329a54a8bb0ca747984