### PR TITLE
style: horizontal radio groups

### DIFF
--- a/src/components/UI/ParameterPopup.jsx
+++ b/src/components/UI/ParameterPopup.jsx
@@ -42,7 +42,7 @@ export default function ParameterPopup({ segmentName, initialValues, onSave, onC
       <div className="param-section">
         {/* Updated label to remove trailing colon */}
         <div className="param-title">{__('Patency', 'endoplanner')}</div>
-        <div className="condition-options radio-group">
+        <div className="radio-group condition-options">
           <label className="param-radio">
             <input
               type="radio"

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -653,6 +653,8 @@ svg .vessel-path:hover {
   margin-bottom: 0.25rem;
 }
 
+
+/* layout tweaks when using RadioControl inside selector rows */
 .selector-row .components-radio-control__input-group {
   display: flex;
   gap: 24px;
@@ -660,8 +662,8 @@ svg .vessel-path:hover {
   align-items: center;
 }
 
-/* inline radio groups everywhere */
-.components-radio-control__input-group {
+/* horizontal layout for any group marked with .radio-group */
+.radio-group .components-radio-control__input-group {
   display: flex;
   gap: 12px;
   justify-content: center;


### PR DESCRIPTION
## Summary
- style radio groups with flex so options align horizontally
- update ParameterPopup markup to use `.radio-group`

## Testing
- `npm run build` *(fails: wp-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866e8319d248329a54ecf4067da6af7