### PR TITLE
Refactor closure device UI

### DIFF
--- a/src/components/UI/InlineDeviceSelect.jsx
+++ b/src/components/UI/InlineDeviceSelect.jsx
@@ -1,0 +1,94 @@
+import React, { useState, useEffect, useRef } from 'react';
+import PropTypes from 'prop-types';
+import SegmentedControl from './SegmentedControl';
+import { __ } from '@wordpress/i18n';
+
+export default function InlineDeviceSelect({
+  options,
+  value,
+  onChange,
+  buttonLabel = __('Choose', 'endoplanner'),
+  image,
+}) {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef(null);
+  const baseOptions = options.filter((o) => o !== 'Custom');
+  const hasCustom = options.includes('Custom');
+  const isKnown = baseOptions.includes(value);
+  const [selection, setSelection] = useState(isKnown ? value : hasCustom && value ? 'Custom' : '');
+  const [customText, setCustomText] = useState(isKnown ? '' : value || '');
+
+  useEffect(() => {
+    const known = baseOptions.includes(value);
+    setSelection(known ? value : hasCustom && value ? 'Custom' : '');
+    setCustomText(known ? '' : value || '');
+  }, [value, baseOptions, hasCustom]);
+
+  useEffect(() => {
+    if (!open) return undefined;
+    const handle = (e) => {
+      if (containerRef.current && !containerRef.current.contains(e.target)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handle);
+    return () => document.removeEventListener('mousedown', handle);
+  }, [open]);
+
+  const handleSelect = (val) => {
+    setSelection(val);
+    if (val === 'Custom') {
+      if (!customText) onChange('');
+    } else {
+      onChange(val);
+      setOpen(false);
+    }
+  };
+
+  const handleCustom = (txt) => {
+    setCustomText(txt);
+    onChange(txt);
+  };
+
+  const label = value || buttonLabel;
+
+  return (
+    <div className="inline-device-select" ref={containerRef}>
+      <button
+        type="button"
+        className="device-button"
+        onClick={() => setOpen((o) => !o)}
+      >
+        {image && <img src={image} alt="" />}
+        <span>{label}</span>
+      </button>
+      {open && (
+        <div className="device-dropdown">
+          <SegmentedControl
+            options={[...baseOptions.map((v) => ({ label: v, value: v })), ...(hasCustom ? [{ label: __('Custom', 'endoplanner'), value: 'Custom' }] : [])]}
+            value={selection}
+            onChange={handleSelect}
+            ariaLabel={__('Device', 'endoplanner')}
+          />
+          {selection === 'Custom' && (
+            <input
+              type="text"
+              className="custom-device-input"
+              value={customText}
+              onChange={(e) => handleCustom(e.target.value)}
+              placeholder={__('Enter custom device', 'endoplanner')}
+            />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+InlineDeviceSelect.propTypes = {
+  options: PropTypes.arrayOf(PropTypes.string).isRequired,
+  value: PropTypes.string,
+  onChange: PropTypes.func.isRequired,
+  buttonLabel: PropTypes.string,
+  image: PropTypes.string,
+};

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -899,3 +899,19 @@ svg .vessel-path:hover {
 .vessel-dropdown .dropdown-item.selected {
   background: #e6f0ff;
 }
+
+/* Inline device dropdown used for closure and special devices */
+.inline-device-select {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  position: relative;
+}
+
+.device-dropdown {
+  margin-top: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- add `InlineDeviceSelect` component
- use inline selector for special and closure device choices
- remove old `DeviceModal`
- style inline dropdown

## Testing
- `npm run build` *(fails: wp-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68680c4d0fcc8329bdd7ef910510ef9e