### PR TITLE
Update WiFi text and dropdown layout

### DIFF
--- a/src/components/steps/Step1_Clinical.jsx
+++ b/src/components/steps/Step1_Clinical.jsx
@@ -26,7 +26,7 @@ const wifiDescriptions = {
     3: 'ABI ≤ 0.39; TP < 30 mmHg',
   },
   infection: {
-    0: 'Uninfected',
+    0: 'No signs of infection',
     1: 'Mild local infection, erythema 0.5–2 cm',
     2: 'Moderate infection, >2 cm or deeper tissue',
     3: 'Severe infection with SIRS',

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -694,6 +694,7 @@ svg .vessel-path:hover {
   flex-wrap: wrap;
   gap: 1rem;
   width: 100%;
+  position: relative;
 }
 
 // layout holding one column per device type
@@ -910,15 +911,20 @@ svg .vessel-path:hover {
   display: flex;
   flex-direction: column;
   align-items: center;
-  position: relative;
+  position: static;
 }
 
 .device-dropdown {
-  margin-top: 0.5rem;
+  position: absolute;
+  top: calc(100% + 2rem);
+  left: 0;
+  width: 100%;
   display: flex;
-  flex-direction: column;
-  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
   gap: 0.5rem;
+  margin-top: 0;
+  z-index: 10;
 }
 
 /* Case summary layout */


### PR DESCRIPTION
## Summary
- tweak clinical wifi descriptor text
- reposition inline device dropdowns below selector rows with spacing

## Testing
- `npm run build` *(fails: wp-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868e34109708329893940fd593da6dc