### PR TITLE
Enhance guideline transparency and summary layout

### DIFF
--- a/src/components/UI/ReferencePopup.jsx
+++ b/src/components/UI/ReferencePopup.jsx
@@ -2,18 +2,106 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import InlineModal from './InlineModal';
 
-export default function ReferencePopup({ isOpen, onRequestClose, figure, title }) {
-  const images = {
-    table4:
-      'https://raw.githubusercontent.com/scikit-image/scikit-image/main/skimage/data/camera.png',
-    table5:
-      'https://raw.githubusercontent.com/scikit-image/scikit-image/main/skimage/data/astronaut.png',
-    figure6:
-      'https://raw.githubusercontent.com/scikit-image/scikit-image/main/skimage/data/coins.png',
+export default function ReferencePopup({ isOpen, onRequestClose, figure, title, highlight }) {
+  const Table4 = () => {
+    const rows = [
+      { stage: 1, risk: '1–3%' },
+      { stage: 2, risk: '5–10%' },
+      { stage: 3, risk: '15–25%' },
+      { stage: 4, risk: '30–55%' },
+    ];
+    return (
+      <table className="guideline-table">
+        <thead>
+          <tr>
+            <th>WiFi stage</th>
+            <th>1-year major amputation risk</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((r) => (
+            <tr key={r.stage} className={r.stage === highlight ? 'highlight' : ''}>
+              <td>{r.stage}</td>
+              <td>{r.risk}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    );
   };
+
+  const Table5 = () => {
+    const rows = [
+      { id: 'len10', label: 'Lesion length 10–15cm', change: '+2–5%' },
+      { id: 'len20', label: 'Lesion length >20cm', change: '+5–7%' },
+      { id: 'occl', label: 'Occlusion', change: '+3–5%' },
+      { id: 'modcalc', label: 'Moderate calcification', change: '+1–3%' },
+      { id: 'heavycalc', label: 'Heavy calcification', change: '+3–5%' },
+    ];
+    return (
+      <table className="guideline-table">
+        <thead>
+          <tr>
+            <th>Characteristic</th>
+            <th>Risk increase</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((r) => (
+            <tr key={r.id} className={highlight?.includes(r.id) ? 'highlight' : ''}>
+              <td>{r.label}</td>
+              <td>{r.change}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    );
+  };
+
+  const Figure6 = () => {
+    const rows = [
+      { stage: 'I', success: '95–98%', patency: '80–90%' },
+      { stage: 'II', success: '85–90%', patency: '60–70%' },
+      { stage: 'III', success: '65–80%', patency: '40–55%' },
+    ];
+    return (
+      <table className="guideline-table">
+        <thead>
+          <tr>
+            <th>GLASS stage</th>
+            <th>Technical success</th>
+            <th>1-year primary patency</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((r) => (
+            <tr key={r.stage} className={r.stage === highlight ? 'highlight' : ''}>
+              <td>{r.stage}</td>
+              <td>{r.success}</td>
+              <td>{r.patency}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    );
+  };
+
+  const renderFigure = () => {
+    switch (figure) {
+      case 'table4':
+        return <Table4 />;
+      case 'table5':
+        return <Table5 />;
+      case 'figure6':
+        return <Figure6 />;
+      default:
+        return null;
+    }
+  };
+
   return (
     <InlineModal title={title} isOpen={isOpen} onRequestClose={onRequestClose}>
-      <img src={images[figure]} alt={title} style={{ maxWidth: '100%' }} />
+      {renderFigure()}
       <div className="popup-close-row">
         <button type="button" className="circle-btn close-modal-btn" onClick={onRequestClose}>
           &times;
@@ -28,4 +116,9 @@ ReferencePopup.propTypes = {
   onRequestClose: PropTypes.func.isRequired,
   figure: PropTypes.oneOf(['table4', 'table5', 'figure6']).isRequired,
   title: PropTypes.string.isRequired,
+  highlight: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string,
+    PropTypes.arrayOf(PropTypes.string),
+  ]),
 };

--- a/src/components/steps/Step3_Summary.jsx
+++ b/src/components/steps/Step3_Summary.jsx
@@ -38,6 +38,12 @@ export default function StepSummary({ data }) {
 
   const wifiCode = `W${prog.wound}I${prog.ischemia}fI${prog.infection}`;
 
+  const table5Highlight = [];
+  if (prog.lengthCategory) table5Highlight.push(prog.lengthCategory);
+  if (prog.hasOcclusion) table5Highlight.push('occl');
+  if (prog.maxCalcium === 'moderate') table5Highlight.push('modcalc');
+  if (prog.maxCalcium === 'heavy') table5Highlight.push('heavycalc');
+
   const lengthImpact = prog.totalLength > 20 ? '+5–7%' : prog.totalLength > 10 ? '+2–5%' : 'no increase';
   const occlImpact = prog.hasOcclusion ? '+3–5%' : 'no increase';
   const calcImpact =
@@ -55,12 +61,12 @@ export default function StepSummary({ data }) {
     const sheaths = summarizeList(row.sheaths);
     const cats = summarizeList(row.catheters);
     return (
-      <li key={`a${i}`}>{
-        `#${i + 1}: ${row.approach || ''} via ${row.vessel || ''}` +
-        (needles ? `; Needles: ${needles}` : '') +
-        (sheaths ? `; Sheaths: ${sheaths}` : '') +
-        (cats ? `; Catheters: ${cats}` : '')
-      }</li>
+      <li key={`a${i}`}>
+        <div>{`#${i + 1}: ${row.approach || ''} via ${row.side || ''} ${row.vessel || ''}`}</div>
+        {needles && <div>{`Needle(s): ${needles}`}</div>}
+        {sheaths && <div>{`Sheath(s): ${sheaths}`}</div>}
+        {cats && <div>{`Catheter(s): ${cats}`}</div>}
+      </li>
     );
   };
 
@@ -125,17 +131,17 @@ export default function StepSummary({ data }) {
         </div>
         <div className="summary-card">
           <h3>{__('Evidence based considerations', 'endoplanner')}</h3>
-          <p>{`WIfI stage: ${prog.wifiStage}`}</p>
+          <p>{`WiFi: ${wifiCode} → WiFi stage ${prog.wifiStage}`}</p>
           <p>
-            {`WIfI stage ${prog.wifiStage} indicates an intermediate risk for major amputation at 1 year, estimated at ${prog.baseAmpRange[0]}–${prog.baseAmpRange[1]}% `}
+            {`WiFi stage ${prog.wifiStage} is associated with a 1-year major amputation risk of ${prog.baseAmpRange[0]}–${prog.baseAmpRange[1]}% `}
             <ReferenceLink number={1} onClick={() => setShowRef1(true)} />
           </p>
           <p>
-            {`Given a lesion length ${prog.totalLength > 10 ? '>' : ''}${prog.totalLength}cm (increase ${lengthImpact}), ${prog.hasOcclusion ? 'occlusion' : 'stenosis'} (${occlImpact}), and ${prog.maxCalcium} calcification (${calcImpact}), the adjusted 1-year major amputation risk is ${prog.ampRange[0]}–${prog.ampRange[1]}% `}
+            {`Lesion length ${prog.totalLength > 10 ? (prog.totalLength > 20 ? '>20cm' : '10–15cm') : '<10cm'} (${lengthImpact}), ${prog.hasOcclusion ? 'occlusion' : 'stenosis'} (${occlImpact}), and ${prog.maxCalcium} calcification (${calcImpact}) adjust the risk estimate. Adjusted risk: ${prog.ampRange[0]}–${prog.ampRange[1]}% `}
             <ReferenceLink number={2} onClick={() => setShowRef2(true)} />
           </p>
           <p>
-            {`GLASS ${glass.stage} indicates a technical success of ${glass.successRange[0]}–${glass.successRange[1]}% and a 1-year primary patency of ${glass.patencyRange[0]}–${glass.patencyRange[1]}% following endovascular revascularization `}
+            {`GLASS ${glass.stage} predicts ${glass.successRange[0]}–${glass.successRange[1]}% technical success and ${glass.patencyRange[0]}–${glass.patencyRange[1]}% 1-year primary patency after endovascular treatment `}
             <ReferenceLink number={3} onClick={() => setShowRef3(true)} />
           </p>
         </div>
@@ -180,18 +186,21 @@ export default function StepSummary({ data }) {
         onRequestClose={() => setShowRef1(false)}
         figure="table4"
         title="CLTI Guidelines 2021 – Table 4"
+        highlight={prog.wifiStage}
       />
       <ReferencePopup
         isOpen={showRef2}
         onRequestClose={() => setShowRef2(false)}
         figure="table5"
         title="CLTI Guidelines 2021 – Table 5"
+        highlight={table5Highlight}
       />
       <ReferencePopup
         isOpen={showRef3}
         onRequestClose={() => setShowRef3(false)}
         figure="figure6"
         title="CLTI Guidelines 2021 – Figure 6"
+        highlight={glass.stage}
       />
     </div>
   );

--- a/src/components/steps/Step4_Intervention.jsx
+++ b/src/components/steps/Step4_Intervention.jsx
@@ -688,6 +688,12 @@ function AccessRow({ index, values, onChange, onAdd, onRemove, showRemove }) {
           onChange={(val) => { console.log('Access approach', val); onChange({ ...data, approach: val }); }}
           ariaLabel={__('Approach', 'endoplanner')}
         />
+        <SegmentedControl
+          options={[{ label: 'Left', value: 'Left' }, { label: 'Right', value: 'Right' }]}
+          value={data.side || ''}
+          onChange={(val) => onChange({ ...data, side: val })}
+          ariaLabel="Side"
+        />
         <div className="device-grid">
           <div className="device-column">
             <DeviceButton
@@ -834,7 +840,14 @@ function AccessRow({ index, values, onChange, onAdd, onRemove, showRemove }) {
   );
 }
 
-AccessRow.propTypes = { index: PropTypes.number.isRequired, values: PropTypes.object, onChange: PropTypes.func.isRequired, onAdd: PropTypes.func.isRequired, onRemove: PropTypes.func.isRequired, showRemove: PropTypes.bool };
+AccessRow.propTypes = {
+  index: PropTypes.number.isRequired,
+  values: PropTypes.object,
+  onChange: PropTypes.func.isRequired,
+  onAdd: PropTypes.func.isRequired,
+  onRemove: PropTypes.func.isRequired,
+  showRemove: PropTypes.bool,
+};
 
 function NavRow({ index, values, onChange, onAdd, onRemove, showRemove }) {
   const [wireOpen, setWireOpen] = useState(false);

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -885,6 +885,20 @@ svg .vessel-path:hover {
   color: #fff;
 }
 
+.guideline-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 1rem;
+}
+.guideline-table th,
+.guideline-table td {
+  border: 1px solid #ccc;
+  padding: 0.25rem 0.5rem;
+}
+.guideline-table .highlight {
+  background: #fffa8b;
+}
+
 .vessel-dropdown {
   list-style: none;
   margin: 0;

--- a/src/utils/prognosis.js
+++ b/src/utils/prognosis.js
@@ -26,6 +26,8 @@ export default function computePrognosis(data = {}) {
     else if (calcium === 'moderate' && maxCalcium !== 'heavy') maxCalcium = 'moderate';
   });
 
+  let lengthCategory = totalLength > 20 ? 'len20' : totalLength > 10 ? 'len10' : null;
+
   let min = ampRange[0];
   let max = ampRange[1];
   if (totalLength > 20) { min += 5; max += 7; limbSalvage -= 5; }
@@ -48,5 +50,6 @@ export default function computePrognosis(data = {}) {
     totalLength,
     hasOcclusion,
     maxCalcium,
+    lengthCategory,
   };
 }


### PR DESCRIPTION
## Summary
- add interactive guideline tables with row highlighting in `ReferencePopup`
- show WiFi code and clearer risk text in summary
- highlight risk modifiers and GLASS stage references
- support left/right selection for access rows
- style guideline tables for clarity
- expose lesion-length category in `computePrognosis`

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68694ce472c4832985381d2ed7424948