### PR TITLE
Fix PDF export styling

### DIFF
--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -1,0 +1,6 @@
+:root {
+  --param-btn-bg: #000;
+  --param-btn-hover-bg: #232323;
+  --param-btn-active-bg: #e0e0e0;
+  --param-btn-text: #fff;
+}

--- a/src/utils/exportPdf.js
+++ b/src/utils/exportPdf.js
@@ -1,41 +1,38 @@
 import html2pdf from 'html2pdf.js/dist/html2pdf.min.js';
-import summaryCss from './summaryCss';
+import summaryCss from '../styles/summary.css?inline';
+import variablesCss from '../styles/variables.css?inline';
 
 export async function exportCaseSummary() {
-  const source = document.getElementById('case-summary') || document.querySelector('.case-summary-container');
-  if (!source) return;
+  const src = document.getElementById('case-summary') || document.querySelector('.case-summary-container');
+  if (!src) return;
 
-  const printFrame = document.createElement('iframe');
-  printFrame.style.position = 'absolute';
-  printFrame.style.left = '-10000px';
-  printFrame.style.top = '0';
-  document.body.appendChild(printFrame);
+  const frame = document.createElement('iframe');
+  frame.style.position = 'fixed';
+  frame.style.right = '100%';
+  frame.style.width = frame.style.height = '0';
+  document.body.appendChild(frame);
 
-  const doc = printFrame.contentDocument;
-  doc.open();
-  doc.write('<!DOCTYPE html><html><head></head><body></body></html>');
-  doc.close();
+  const clone = src.cloneNode(true);
+  frame.contentDocument.body.appendChild(clone);
 
-  const clone = source.cloneNode(true);
-  doc.body.appendChild(clone);
+  const styleTag = frame.contentDocument.createElement('style');
+  styleTag.textContent = variablesCss + summaryCss;
+  frame.contentDocument.head.appendChild(styleTag);
 
-  const style = doc.createElement('style');
-  style.textContent = summaryCss;
-  doc.head.appendChild(style);
-
-  await doc.fonts.ready;
-  const images = Array.from(doc.images);
-  await Promise.all(images.map((img) => img.decode().catch(() => {})));
+  await frame.contentDocument.fonts.ready;
+  await Promise.all(
+    Array.from(frame.contentDocument.images).map((img) => img.decode())
+  );
 
   const opt = {
     margin: 10,
     filename: 'CaseSummary.pdf',
-    html2canvas: { scale: 2, useCORS: true },
+    html2canvas: { background: '#ffffff', scale: 2, useCORS: true },
     jsPDF: { unit: 'mm', format: 'a4', orientation: 'portrait' },
   };
 
-  await html2pdf().set(opt).from(doc.body).save();
-  printFrame.remove();
+  await html2pdf().set(opt).from(clone).save();
+  document.body.removeChild(frame);
 }
 
 export default exportCaseSummary;


### PR DESCRIPTION
## Summary
- inline all case summary styles and variables during PDF export
- include CSS variable definitions in separate file

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686c2d30fac88329810f94fa2d3f6863