### PR TITLE
Add case summary wrapper and fix PDF export

### DIFF
--- a/src/components/steps/Step3_Summary.jsx
+++ b/src/components/steps/Step3_Summary.jsx
@@ -405,7 +405,8 @@ export default function StepSummary({ data, setData, setStep }) {
   );
 
   return (
-    <div className="case-summary-container">
+    <div id="case-summary" className="summary-card-wrapper">
+      <div className="case-summary-container">
       <div className="summary-row row1">
         <div className="summary-card">
           <div className="card-title">{__('Clinical indication', 'endoplanner')}</div>
@@ -534,6 +535,7 @@ export default function StepSummary({ data, setData, setStep }) {
           }
         />
       )}
+      </div>
     </div>
   );
 }

--- a/src/utils/exportPdf.js
+++ b/src/utils/exportPdf.js
@@ -1,36 +1,41 @@
-import html2pdf from 'html2pdf.js';
+import html2pdf from "html2pdf.js";
 
 export async function exportPDF() {
-  const summary = document.getElementById('case-summary');
+  const summary =
+    document.getElementById("case-summary") ||
+    document.querySelector(".summary-card-wrapper");
+
   if (!summary) {
-    alert('Case Summary not found');
+    alert("Could not locate Case Summary in the DOM.");
     return;
   }
 
   const clone = summary.cloneNode(true);
-  clone.id = 'print-summary';
-  clone.style.display = 'block';
+  clone.id = "print-summary";
+  clone.style.display = "block";
 
-  const link = document.createElement('link');
-  link.rel = 'stylesheet';
-  link.href = '/assets/css/summary.css';
+  const link = document.createElement("link");
+  link.rel = "stylesheet";
+  link.href = "/assets/css/summary.css";
   clone.prepend(link);
 
   document.body.appendChild(clone);
 
   await html2pdf()
     .set({
-      filename: 'CaseSummary.pdf',
+      filename: "CaseSummary.pdf",
       margin: 10,
       html2canvas: { scale: 2, useCORS: true },
-      pagebreak: { mode: ['avoid-all'] },
-      jsPDF: { unit: 'mm', format: 'a4', orientation: 'portrait' },
-      printMediaType: true
+      pagebreak: { mode: ["avoid-all"] },
+      jsPDF: { unit: "mm", format: "a4", orientation: "portrait" },
+      printMediaType: true,
     })
     .from(clone)
     .save();
 
   clone.remove();
 }
+
+export const handleExportClick = () => setTimeout(exportPDF, 0);
 
 export default exportPDF;


### PR DESCRIPTION
## Summary
- ensure `case-summary` element always exists by wrapping output
- make exportPDF more robust and expose a debounced click handler

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686e30694c3c8329a0ea30f9c813127b