### PR TITLE
Fix PDF export text alignment

### DIFF
--- a/src/pdf/pdf-summary.css
+++ b/src/pdf/pdf-summary.css
@@ -2,7 +2,9 @@
 
 /* 1 – Reset any inherited centring */
 .pdf-wrapper,
-.pdf-wrapper * {
+.pdf-wrapper *,
+#print-summary,
+#print-summary * {
     text-align: left !important;
 }
 


### PR DESCRIPTION
## Summary
- ensure `#print-summary` also enforces left-aligned text in the PDF export

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686e3901419483298ab3b954de352773