### PR TITLE
Fix PDF alignment for intervention plan

### DIFF
--- a/src/pdf/pdf-summary.css
+++ b/src/pdf/pdf-summary.css
@@ -33,3 +33,17 @@
 .case-summary-container,#case-summary{margin:0!important;}
 .plan-list{align-items:flex-start!important;}
 .plan-grid{justify-content:flex-start!important;}
+
+/* 6 – Center intervention plan content except the main title */
+#print-summary .intervention-plan * {
+    text-align: center !important;
+}
+#print-summary .intervention-plan .main-plan-title {
+    text-align: left !important;
+}
+#print-summary .intervention-plan .plan-list {
+    align-items: center !important;
+}
+#print-summary .intervention-plan .plan-grid {
+    justify-content: center !important;
+}


### PR DESCRIPTION
## Summary
- center Intervention Plan content in PDF export
- keep main plan title left aligned

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686e3fb466548329bc6d655fde752591