### PR TITLE
Add defaults and shaft options

### DIFF
--- a/src/components/AccessSelector.js
+++ b/src/components/AccessSelector.js
@@ -1,0 +1,14 @@
+import { useEffect } from 'react';
+import { DEFAULTS } from './defaults';
+
+export default function AccessSelector({ dispatch, state, setNeedle, setSheath, setCatheter, children }) {
+  useEffect(() => {
+    if (state && !state.needles && !state.sheaths && !state.catheters) {
+      if (setNeedle)  dispatch ? dispatch(setNeedle(DEFAULTS.access.needle)) : setNeedle(DEFAULTS.access.needle);
+      if (setSheath)  dispatch ? dispatch(setSheath(DEFAULTS.access.sheath)) : setSheath(DEFAULTS.access.sheath);
+      if (setCatheter) dispatch ? dispatch(setCatheter(DEFAULTS.access.catheter)) : setCatheter(DEFAULTS.access.catheter);
+    }
+  }, []); // run once
+
+  return children || null;
+}

--- a/src/components/BalloonModal.js
+++ b/src/components/BalloonModal.js
@@ -1,0 +1,81 @@
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { SelectControl } from '@wordpress/components';
+import InlineModal from './UI/InlineModal';
+import SegmentedControl from './UI/SegmentedControl';
+import { DEFAULTS } from './defaults';
+
+export default function BalloonModal({ isOpen, anchor, onRequestClose, values, onSave }) {
+  const def = DEFAULTS.therapy.balloon;
+  const [platform, setPlatform] = useState(values.platform || def.platform || '');
+  const [diameter, setDiameter] = useState(values.diameter || def.diameter || '');
+  const [len, setLen] = useState(values.length || def.length || '');
+  const [shaft, setShaft] = useState(values.shaft || def.shaft || '');
+
+  useEffect(() => {
+    setPlatform(values.platform || def.platform || '');
+    setDiameter(values.diameter || def.diameter || '');
+    setLen(values.length || def.length || '');
+    setShaft(values.shaft || def.shaft || '');
+  }, [values]);
+
+  const diameters = {
+    '0.014': ['1.5','2','2.5','3.5','4'],
+    '0.018': ['2','2.5','3','4','5','5.5','6','7'],
+    '0.035': ['3','4','5','6','7','8','9','10','12','14']
+  };
+  const lengths = ['10','12','15','18','20','30','40','50','60','70','80','90','100','110','120','250'];
+  const handleChange = (field, val) => {
+    const newVals = { platform, diameter, length: len, shaft, [field]: val };
+    if (field === 'platform') {
+      setPlatform(val);
+      setDiameter(val ? diameters[val][0] : '');
+    }
+    if (field === 'diameter') setDiameter(val);
+    if (field === 'length') setLen(val);
+    if (field === 'shaft') setShaft(val);
+    onSave({ platform: newVals.platform, diameter: newVals.diameter, length: newVals.length, shaft: newVals.shaft });
+    if (newVals.platform && newVals.diameter && newVals.length && newVals.shaft) onRequestClose();
+  };
+
+  return (
+    <InlineModal title="PTA Balloon" isOpen={isOpen} anchor={anchor} onRequestClose={onRequestClose}>
+      <SegmentedControl
+        options={['0.014','0.018','0.035'].map(v => ({ label: v, value: v }))}
+        value={platform}
+        onChange={(val) => handleChange('platform', val)}
+        ariaLabel="Platform"
+      />
+      <SelectControl
+        label="Diameter"
+        value={diameter}
+        options={(diameters[platform] || []).map(v => ({ label:v, value:v }))}
+        onChange={(val)=>handleChange('diameter', val)}
+      />
+      <SelectControl
+        label="Length (mm)"
+        value={len}
+        options={[{ label: 'Choose length', value: '', disabled: true }, ...lengths.map(v => ({ label: v, value: v }))]}
+        onChange={(val) => handleChange('length', val)}
+      />
+      <SelectControl
+        label="Shaft length"
+        value={shaft}
+        className="selector--sm"
+        options={[{ label: '80 cm', value: '80 cm' }, { label: '135 cm', value: '135 cm' }]}
+        onChange={(val) => handleChange('shaft', val)}
+      />
+      <div className="popup-close-row">
+        <button type="button" className="circle-btn close-modal-btn" onClick={onRequestClose}>&times;</button>
+      </div>
+    </InlineModal>
+  );
+}
+
+BalloonModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  anchor: PropTypes.object,
+  onRequestClose: PropTypes.func.isRequired,
+  values: PropTypes.object,
+  onSave: PropTypes.func.isRequired,
+};

--- a/src/components/StentModal.js
+++ b/src/components/StentModal.js
@@ -1,0 +1,100 @@
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { SelectControl } from '@wordpress/components';
+import InlineModal from './UI/InlineModal';
+import SegmentedControl from './UI/SegmentedControl';
+import { DEFAULTS } from './defaults';
+
+const stentDia = { '0.014':['2','3','4','5'], '0.018':['4','5','6','7'], '0.035':['5','6','7','8','9','10'] };
+const stentLen = { '0.014':['20','40','60','80'], '0.018':['40','60','80','100'], '0.035':['40','60','80','100','120'] };
+
+export default function StentModal({ isOpen, anchor, onRequestClose, values, onSave }) {
+  const def = DEFAULTS.therapy.stent;
+  const [platform, setPlatform] = useState(values.platform || '');
+  const [type, setType] = useState(values.type || '');
+  const [mat, setMat] = useState(values.material || '');
+  const [dia, setDia] = useState(values.diameter || '');
+  const [len, setLen] = useState(values.length || '');
+  const [shaft, setShaft] = useState(values.shaft || def.shaft || '');
+
+  useEffect(() => {
+    setPlatform(values.platform || '');
+    setType(values.type || '');
+    setMat(values.material || '');
+    setDia(values.diameter || '');
+    setLen(values.length || '');
+    setShaft(values.shaft || def.shaft || '');
+  }, [values]);
+
+  const handleChange = (field, val) => {
+    const newVals = { platform, type, material: mat, diameter: dia, length: len, shaft, [field]: val };
+    switch(field){
+      case 'platform':
+        setPlatform(val);
+        setDia(val ? stentDia[val][0] : '');
+        setLen(val ? stentLen[val][0] : '');
+        break;
+      case 'type': setType(val); break;
+      case 'material': setMat(val); break;
+      case 'diameter': setDia(val); break;
+      case 'length': setLen(val); break;
+      case 'shaft': setShaft(val); break;
+      default: break;
+    }
+    onSave({ platform: newVals.platform, type: newVals.type, material: newVals.material, diameter: newVals.diameter, length: newVals.length, shaft: newVals.shaft });
+    if (newVals.platform && newVals.type && newVals.material && newVals.diameter && newVals.length && newVals.shaft) onRequestClose();
+  };
+
+  return (
+    <InlineModal title="Stent" isOpen={isOpen} anchor={anchor} onRequestClose={onRequestClose}>
+      <SegmentedControl
+        options={['0.014','0.018','0.035'].map(v => ({ label: v, value: v }))}
+        value={platform}
+        onChange={(val)=>handleChange('platform', val)}
+        ariaLabel="Platform"
+      />
+      <SegmentedControl
+        options={[{label:'self expandable',value:'self expandable'},{label:'balloon expandable',value:'balloon expandable'}]}
+        value={type}
+        onChange={(val)=>handleChange('type', val)}
+        ariaLabel="Stent type"
+      />
+      <SegmentedControl
+        options={[{label:'bare metal',value:'bare metal'},{label:'covered',value:'covered'}]}
+        value={mat}
+        onChange={(val)=>handleChange('material', val)}
+        ariaLabel="Stent material"
+      />
+      <SelectControl
+        label="Diameter"
+        value={dia}
+        options={[{ label: 'Choose diameter', value: '', disabled: true }, ...(stentDia[platform] || []).map(v => ({ label: v, value: v }))]}
+        onChange={(val) => handleChange('diameter', val)}
+      />
+      <SelectControl
+        label="Length"
+        value={len}
+        options={[{ label: 'Choose length', value: '', disabled: true }, ...(stentLen[platform] || []).map(v => ({ label: v, value: v }))]}
+        onChange={(val) => handleChange('length', val)}
+      />
+      <SelectControl
+        label="Shaft length"
+        value={shaft}
+        className="selector--sm"
+        options={[{ label: '80 cm', value: '80 cm' }, { label: '135 cm', value: '135 cm' }]}
+        onChange={(val) => handleChange('shaft', val)}
+      />
+      <div className="popup-close-row">
+        <button type="button" className="circle-btn close-modal-btn" onClick={onRequestClose}>&times;</button>
+      </div>
+    </InlineModal>
+  );
+}
+
+StentModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  anchor: PropTypes.object,
+  onRequestClose: PropTypes.func.isRequired,
+  values: PropTypes.object,
+  onSave: PropTypes.func.isRequired,
+};

--- a/src/components/WireModal.js
+++ b/src/components/WireModal.js
@@ -1,0 +1,105 @@
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { SelectControl } from '@wordpress/components';
+import InlineModal from './UI/InlineModal';
+import SegmentedControl from './UI/SegmentedControl';
+import { DEFAULTS } from './defaults';
+
+export default function WireModal({ isOpen, anchor, onRequestClose, values, onSave }) {
+  const defaults = DEFAULTS.navigation.wire;
+  const [platform, setPlatform] = useState(values.platform || defaults.size || '');
+  const [length, setLength] = useState(values.length || defaults.length || '');
+  const [type, setType] = useState(values.type || defaults.brand || '');
+  const [body, setBody] = useState(values.body || '');
+  const [support, setSupport] = useState(values.support || '');
+  const [technique, setTechnique] = useState(values.technique || defaults.track || '');
+  const [product, setProduct] = useState(values.product || '');
+
+  useEffect(() => {
+    setPlatform(values.platform || defaults.size || '');
+    setLength(values.length || defaults.length || '');
+    setType(values.type || defaults.brand || '');
+    setBody(values.body || '');
+    setSupport(values.support || '');
+    setTechnique(values.technique || defaults.track || '');
+    setProduct(values.product || '');
+  }, [values]);
+
+  const lengths = ['180 cm','260 cm','300 cm'];
+  const bodyOpts = ['Light bodied','Intermediate bodied','Heavy bodied'];
+  const supportOpts = ['Rosen wire','Lunderquist wire','Amplatz wire','Bentson wire','Meier wire','Newton wire'];
+  const handleChange = (field, val) => {
+    const newVals = { platform, length, type, body, support, technique, product, [field]: val };
+    switch(field){
+      case 'platform': setPlatform(val); break;
+      case 'length': setLength(val); break;
+      case 'type': setType(val); break;
+      case 'body': setBody(val); break;
+      case 'support': setSupport(val); break;
+      case 'technique': setTechnique(val); break;
+      case 'product': setProduct(val); break;
+      default: break;
+    }
+    onSave(newVals);
+    if (newVals.platform && newVals.length && newVals.type && newVals.technique) onRequestClose();
+  };
+  return (
+    <InlineModal title="Wire" isOpen={isOpen} anchor={anchor} onRequestClose={onRequestClose}>
+      <SegmentedControl
+        options={['0.014','0.018','0.035'].map(v => ({ label: v, value: v }))}
+        value={platform}
+        onChange={(val)=>handleChange('platform', val)}
+        ariaLabel="Platform"
+      />
+      <SelectControl label="Length" value={length} options={lengths.map(v => ({ label:v, value:v }))} onChange={(val)=>handleChange('length', val)} />
+      <SegmentedControl
+        options={[{label:'Glidewire',value:'Glidewire'},{label:'CTO wire',value:'CTO wire'},{label:'Support wire',value:'Support wire'}]}
+        value={type}
+        onChange={(val)=>handleChange('type', val)}
+        ariaLabel="Type"
+      />
+      {type === 'CTO wire' && (
+        <SelectControl
+          label="Body type"
+          value={body}
+          options={[{ label: 'Choose body', value: '', disabled: true }, ...bodyOpts.map(v => ({ label: v, value: v }))]}
+          onChange={(val) => handleChange('body', val)}
+        />
+      )}
+      {type === 'Support wire' && (
+        <SelectControl
+          label="Support wire"
+          value={support}
+          options={[{ label: 'Choose wire', value: '', disabled: true }, ...supportOpts.map(v => ({ label: v, value: v }))]}
+          onChange={(val) => handleChange('support', val)}
+        />
+      )}
+      <SegmentedControl
+        options={[
+          {label:'Intimal Tracking',value:'Intimal Tracking'},
+          {label:'Limited sub-intimal dissection and re-entry',value:'Limited sub-intimal dissection and re-entry'}
+        ]}
+        value={technique}
+        onChange={(val)=>handleChange('technique', val)}
+        ariaLabel="Technique"
+      />
+      <SelectControl
+        label="Product"
+        value={product}
+        options={[{ label: 'Choose product', value: '', disabled: true }, { label: 'None', value: 'none' }]}
+        onChange={(val)=>handleChange('product', val)}
+      />
+      <div className="popup-close-row">
+        <button type="button" className="circle-btn close-modal-btn" onClick={onRequestClose}>&times;</button>
+      </div>
+    </InlineModal>
+  );
+}
+
+WireModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  anchor: PropTypes.object,
+  onRequestClose: PropTypes.func.isRequired,
+  values: PropTypes.object,
+  onSave: PropTypes.func.isRequired,
+};

--- a/src/components/defaults.js
+++ b/src/components/defaults.js
@@ -1,0 +1,14 @@
+export const DEFAULTS = {
+  access: {
+    needle   : { gauge: '19 G', length: '7 cm' },
+    sheath   : { fr: '6 F',  length: '12 cm' },
+    catheter : { model: 'BER2', fr: '4 F', length: '65 cm' }
+  },
+  navigation: {
+    wire     : { size: '0.018', length: '180 cm', brand: 'Glidewire', track: 'Intimal tracking' }
+  },
+  therapy: {
+    balloon  : { platform: '0.018', diameter: '5 mm', length: '100 mm', shaft: '80 cm' },
+    stent    : { shaft: '80 cm' }
+  }
+};

--- a/src/components/steps/Step3_Summary.jsx
+++ b/src/components/steps/Step3_Summary.jsx
@@ -180,7 +180,8 @@ const summarizeList = (arr) =>
 const formatTherapy = (obj) => {
   if (!obj || typeof obj !== 'object') return '';
   if (obj.diameter && obj.length) {
-    return `${obj.diameter} \u00D7 ${obj.length} mm`;
+    const shaft = obj.shaft ? ` \u00B7 shaft ${obj.shaft}` : '';
+    return `${obj.diameter} \u00D7 ${obj.length} mm${shaft}`;
   }
   return summarize(obj);
 };


### PR DESCRIPTION
## Summary
- centralize common defaults
- add default-filler AccessSelector
- update device modals for defaults and new shaft option
- show shaft length in therapy summary

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687412214d888329a96179750aaf055e