### PR TITLE
Richer local preference descriptions and two-line subtitle display

### DIFF
--- a/src/components/steps/Step4_Intervention.jsx
+++ b/src/components/steps/Step4_Intervention.jsx
@@ -168,10 +168,68 @@ const shortLabel = (type, obj) => {
   }
 };
 
+const getDisplayLabel = (obj) => {
+  if (!obj || typeof obj !== 'object') return '';
+  return obj.label || obj.name || obj.title || obj.displayLabel || '';
+};
+
+const joinPreferenceParts = (parts) =>
+  parts
+    .map((part) => (typeof part === 'string' ? part.trim() : part))
+    .filter((part) => part && String(part).trim().length > 0)
+    .join(' • ');
+
+const formatWireLabel = (value) => {
+  const size = value.platform || '';
+  const length = value.length || '';
+  const type = value.type || '';
+  const product = value.product && value.product !== 'none' ? value.product : '';
+  const modifierParts = [value.technique, value.body, value.support].filter(Boolean);
+  const productParts = [];
+  if (type) productParts.push(type);
+  if (product && product !== type) productParts.push(product);
+  return joinPreferenceParts([size, length, ...productParts, ...modifierParts]);
+};
+
+const formatBalloonLabel = (value) => {
+  const size = value.platform || '';
+  const diameter = value.diameter ? `${value.diameter}mm` : '';
+  const length = value.length ? `${value.length}mm` : '';
+  const shaft = value.shaft || '';
+  return joinPreferenceParts([size, diameter, length, shaft]);
+};
+
+const formatStentLabel = (value) => {
+  const size = value.platform || '';
+  const diameter = value.diameter ? `${value.diameter}mm` : '';
+  const length = value.length ? `${value.length}mm` : '';
+  const type = value.type || '';
+  const material = value.material || '';
+  const shaft = value.shaft || '';
+  return joinPreferenceParts([size, diameter, length, type, material, shaft]);
+};
+
 const getPreferenceLabel = (type, value) => {
   if (!value) return '';
   if (typeof value === 'string') return value;
-  return shortLabel(type, value);
+  const displayLabel = getDisplayLabel(value);
+  if (displayLabel) return displayLabel;
+  switch (type) {
+    case 'needle':
+      return joinPreferenceParts([value.size, value.length]);
+    case 'sheath':
+      return joinPreferenceParts([value.frSize, value.length]);
+    case 'catheter':
+      return joinPreferenceParts([value.specific, value.frSize, value.length]);
+    case 'wire':
+      return formatWireLabel(value);
+    case 'balloon':
+      return formatBalloonLabel(value);
+    case 'stent':
+      return formatStentLabel(value);
+    default:
+      return summarize(value);
+  }
 };
 
 // Deserialize cookie payload into preference slots for the UI.

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -839,6 +839,7 @@ svg .vessel-path:hover {
   font-size: 0.6rem;
   color: #4b5b91;
   text-align: center;
+  width: 72px;
   max-width: 72px;
   line-height: 1.2;
   display: -webkit-box;


### PR DESCRIPTION
### Motivation
- Preference slot descriptions were overly truncated (e.g., showing only `0.018`) and did not reflect the human-readable display label shown in selectors.
- The description should present a concise, ordered composition of key attributes (size → length → product/type → modifier) and be allowed to occupy more vertical space for readability.

### Description
- Compute preference descriptions from a preferred display property (`label`, `name`, `title`, `displayLabel`) and fall back to composed attribute summaries when absent, preserving stored preference data unchanged.
- Added helpers `getDisplayLabel`, `joinPreferenceParts`, `formatWireLabel`, `formatBalloonLabel`, and `formatStentLabel` and updated `getPreferenceLabel` to produce richer labels (e.g., `0.018 • 180cm • Glidewire • Intimal Tracking`).
- Adjusted CSS for the preference subtitle to match button width and permit up to two lines with `-webkit-line-clamp: 2` and ellipsis if still overflowing.
- Files changed: `src/components/steps/Step4_Intervention.jsx`, `src/styles/style.scss`.

### Testing
- No automated tests were run for this change.
- Changes were committed and are ready for UI verification in the app (select the preference `0.018 180cm Glidewire for intimal tracking` and confirm the prefs subtitle reads like `0.018 • 180cm • Glidewire • Intimal Tracking` and wraps to two lines before ellipsis).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a10a915b88329b15df111c8217936)